### PR TITLE
refactor: rename directory name from preprocess to process

### DIFF
--- a/mmros/include/mmros/process/image.hpp
+++ b/mmros/include/mmros/process/image.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef MMROS__PREPROCESS__IMAGE_HPP_
-#define MMROS__PREPROCESS__IMAGE_HPP_
+#ifndef MMROS__PROCESS__IMAGE_HPP_
+#define MMROS__PROCESS__IMAGE_HPP_
 
 #include <cublas_v2.h>
 #include <cuda.h>
@@ -21,7 +21,7 @@
 #include <cuda_runtime_api.h>
 #include <curand.h>
 
-namespace mmros::preprocess
+namespace mmros::process
 {
 struct Roi
 {
@@ -199,5 +199,5 @@ extern void multi_scale_resize_bilinear_letterbox_nhwc_to_nchw32_batch_gpu(
 extern void argmax_gpu(
   unsigned char * dst, float * src, int d_w, int d_h, int s_w, int s_h, int s_c, int batch,
   cudaStream_t stream);
-}  // namespace mmros::preprocess
-#endif  // MMROS__PREPROCESS__IMAGE_HPP_
+}  // namespace mmros::process
+#endif  // MMROS__PROCESS__IMAGE_HPP_

--- a/mmros/src/detector/detector2d.cpp
+++ b/mmros/src/detector/detector2d.cpp
@@ -17,7 +17,7 @@
 #include "mmros/archetype/box.hpp"
 #include "mmros/archetype/exception.hpp"
 #include "mmros/archetype/result.hpp"
-#include "mmros/preprocess/image.hpp"
+#include "mmros/process/image.hpp"
 #include "mmros/tensorrt/cuda_check_error.hpp"
 #include "mmros/tensorrt/cuda_unique_ptr.hpp"
 #include "mmros/tensorrt/utility.hpp"
@@ -179,7 +179,7 @@ void Detector2D::preprocess(const std::vector<cv::Mat> & images)
   CHECK_CUDA_ERROR(::cudaMemcpyAsync(
     std_d.get(), std_h.data(), std_h.size() * sizeof(float), cudaMemcpyHostToDevice, stream_));
 
-  preprocess::resize_bilinear_letterbox_nhwc_to_nchw32_batch_gpu(
+  process::resize_bilinear_letterbox_nhwc_to_nchw32_batch_gpu(
     input_d_.get(), img_buf_d.get(), input_width, input_height, 3, images[0].cols, images[0].rows,
     3, batch_size, mean_d.get(), std_d.get(), stream_);
 

--- a/mmros/src/detector/instance_segmeter2d.cpp
+++ b/mmros/src/detector/instance_segmeter2d.cpp
@@ -16,7 +16,7 @@
 #include "mmros/archetype/exception.hpp"
 #include "mmros/archetype/result.hpp"
 #include "mmros/detector/instance_segmenter2d.hpp"
-#include "mmros/preprocess/image.hpp"
+#include "mmros/process/image.hpp"
 #include "mmros/tensorrt/cuda_check_error.hpp"
 #include "mmros/tensorrt/cuda_unique_ptr.hpp"
 #include "mmros/tensorrt/tensorrt_common.hpp"
@@ -182,7 +182,7 @@ void InstanceSegmenter2D::preprocess(const std::vector<cv::Mat> & images)
   CHECK_CUDA_ERROR(::cudaMemcpyAsync(
     std_d.get(), std_h.data(), std_h.size() * sizeof(float), cudaMemcpyHostToDevice, stream_));
 
-  preprocess::resize_bilinear_letterbox_nhwc_to_nchw32_batch_gpu(
+  process::resize_bilinear_letterbox_nhwc_to_nchw32_batch_gpu(
     input_d_.get(), img_buf_d.get(), input_width, input_height, 3, images[0].cols, images[0].rows,
     3, batch_size, mean_d.get(), std_d.get(), stream_);
 

--- a/mmros/src/detector/panoptic_segmenter2d.cpp
+++ b/mmros/src/detector/panoptic_segmenter2d.cpp
@@ -17,7 +17,7 @@
 #include "mmros/archetype/box.hpp"
 #include "mmros/archetype/exception.hpp"
 #include "mmros/archetype/result.hpp"
-#include "mmros/preprocess/image.hpp"
+#include "mmros/process/image.hpp"
 #include "mmros/tensorrt/cuda_check_error.hpp"
 #include "mmros/tensorrt/cuda_unique_ptr.hpp"
 
@@ -185,7 +185,7 @@ void PanopticSegmenter2D::preprocess(const std::vector<cv::Mat> & images)
   CHECK_CUDA_ERROR(::cudaMemcpyAsync(
     std_d.get(), std_h.data(), std_h.size() * sizeof(float), cudaMemcpyHostToDevice, stream_));
 
-  preprocess::resize_bilinear_letterbox_nhwc_to_nchw32_batch_gpu(
+  process::resize_bilinear_letterbox_nhwc_to_nchw32_batch_gpu(
     input_d_.get(), img_buf_d.get(), input_width, input_height, 3, images[0].cols, images[0].rows,
     3, batch_size, mean_d.get(), std_d.get(), stream_);
 
@@ -208,7 +208,7 @@ archetype::Result<outputs_type> PanopticSegmenter2D::postprocess(
   auto argmax_d =
     cuda::make_unique<unsigned char[]>(batch_size * num_segment * output_height * output_width);
 
-  preprocess::argmax_gpu(
+  process::argmax_gpu(
     argmax_d.get(), out_segments_d_.get(), output_width, output_height, output_width, output_height,
     num_segment, batch_size, stream_);
 

--- a/mmros/src/detector/semantic_segmenter2d.cpp
+++ b/mmros/src/detector/semantic_segmenter2d.cpp
@@ -16,7 +16,7 @@
 
 #include "mmros/archetype/exception.hpp"
 #include "mmros/archetype/result.hpp"
-#include "mmros/preprocess/image.hpp"
+#include "mmros/process/image.hpp"
 #include "mmros/tensorrt/cuda_check_error.hpp"
 #include "mmros/tensorrt/cuda_unique_ptr.hpp"
 
@@ -175,7 +175,7 @@ void SemanticSegmenter2D::preprocess(const std::vector<cv::Mat> & images)
   CHECK_CUDA_ERROR(::cudaMemcpyAsync(
     std_d.get(), std_h.data(), std_h.size() * sizeof(float), cudaMemcpyHostToDevice, stream_));
 
-  preprocess::resize_bilinear_letterbox_nhwc_to_nchw32_batch_gpu(
+  process::resize_bilinear_letterbox_nhwc_to_nchw32_batch_gpu(
     input_d_.get(), img_buf_d.get(), input_width, input_height, 3, images[0].cols, images[0].rows,
     3, batch_size, mean_d.get(), std_d.get(), stream_);
 

--- a/mmros/src/process/image.cu
+++ b/mmros/src/process/image.cu
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "mmros/preprocess/image.hpp"
+#include "mmros/process/image.hpp"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -21,7 +21,7 @@
 
 #define MIN(x, y) x < y ? x : y
 
-namespace mmros::preprocess  // NOLINT
+namespace mmros::process  // NOLINT
 {
 constexpr size_t block = 512;
 
@@ -627,4 +627,4 @@ void argmax_gpu(
   argmax_gpu_kernel<<<cuda_gridsize(N), block, 0, stream>>>(
     N, dst, src, d_h, d_w, s_c, s_h, s_w, batch);
 }
-}  // namespace mmros::preprocess
+}  // namespace mmros::process


### PR DESCRIPTION
## Description

This PR renames the directory for pre/post processes from `preprocess` to `process`.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
