### PR TITLE
fix: input node options

### DIFF
--- a/mmros/src/node/single_camera_node.cpp
+++ b/mmros/src/node/single_camera_node.cpp
@@ -23,7 +23,7 @@
 namespace mmros::node
 {
 SingleCameraNode::SingleCameraNode(const std::string & name, const rclcpp::NodeOptions & options)
-: rclcpp::Node(name)
+: rclcpp::Node(name, options)
 {
   google::InitGoogleLogging(name.c_str());
   google::InstallFailureSignalHandler();


### PR DESCRIPTION
## Description

This pull request makes a small but important change to the `SingleCameraNode` constructor to ensure that node options are correctly passed to the base class constructor.

- Updated the `SingleCameraNode` constructor in `single_camera_node.cpp` to pass `options` to the `rclcpp::Node` base class, ensuring proper node configuration and compatibility with ROS 2 best practices.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
