### PR TITLE
refactor: move duplicated function to utility

### DIFF
--- a/mmros/include/mmros/node/multi_camera_node.hpp
+++ b/mmros/include/mmros/node/multi_camera_node.hpp
@@ -21,7 +21,6 @@
 #include <sensor_msgs/msg/image.hpp>
 
 #include <functional>
-#include <optional>
 #include <string>
 #include <vector>
 
@@ -56,18 +55,17 @@ protected:
   rclcpp::TimerBase::SharedPtr connection_timer_;  //!< Topic connection timer.
 
 private:
+  /**
+   * @brief Connect to a single image topic.
+   *
+   * @param image_topic Image topic name.
+   * @param callback Callback function to be called when a new image is received.
+   * @param use_raw Whether to use raw images or not.
+   * @return True if the connection was successful, false otherwise.
+   */
   bool onConnectForSingleCamera(
     const std::string & image_topic,
     const std::function<void(sensor_msgs::msg::Image::ConstSharedPtr)> & callback, bool use_raw);
-
-  /**
-   * @brief Return QoS of the specified topic.
-   *
-   * If it fails to load the specified QoS, returns `std::nullopt`.
-   *
-   * @param query_topic Topic name.
-   */
-  std::optional<rclcpp::QoS> getTopicQos(const std::string & query_topic);
 
   std::vector<image_transport::Subscriber> subscriptions_;  //!< Subscribers for each camera topic.
 };

--- a/mmros/include/mmros/node/single_camera_node.hpp
+++ b/mmros/include/mmros/node/single_camera_node.hpp
@@ -20,7 +20,6 @@
 
 #include <sensor_msgs/msg/image.hpp>
 
-#include <optional>
 #include <string>
 
 namespace mmros::node
@@ -52,15 +51,6 @@ protected:
   rclcpp::TimerBase::SharedPtr connection_timer_;  //!< Topic connection timer.
 
 private:
-  /**
-   * @brief Return QoS of the specified topic.
-   *
-   * If it fails to load the specified QoS, returns `std::nullopt`.
-   *
-   * @param query_topic Topic name.
-   */
-  std::optional<rclcpp::QoS> getTopicQos(const std::string & query_topic);
-
   image_transport::Subscriber subscription_;  //!< Image subscription.
 };
 }  // namespace mmros::node

--- a/mmros/include/mmros/node/utility.hpp
+++ b/mmros/include/mmros/node/utility.hpp
@@ -1,0 +1,40 @@
+// Copyright 2025 Kotaro Uetake.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MMROS__NODE__UTILITY_HPP_
+#define MMROS__NODE__UTILITY_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <optional>
+#include <string>
+
+namespace mmros::node
+{
+/**
+ * @brief Get the QoS profile of a topic.
+ *
+ * @param node The node to query.
+ * @param topic The topic to query.
+ * @return std::optional<rclcpp::QoS> The QoS profile of the topic, or std::nullopt if the topic is
+ * not published.
+ */
+inline std::optional<rclcpp::QoS> getTopicQos(const rclcpp::Node * node, const std::string & topic)
+{
+  const auto publisher_info = node->get_publishers_info_by_topic(topic);
+  return publisher_info.size() != 1 ? std::nullopt
+                                    : std::make_optional(publisher_info[0].qos_profile());
+}
+}  // namespace mmros::node
+#endif  // MMROS__NODE__UTILITY_HPP_

--- a/mmros/src/node/multi_camera_node.cpp
+++ b/mmros/src/node/multi_camera_node.cpp
@@ -14,6 +14,8 @@
 
 #include "mmros/node/multi_camera_node.hpp"
 
+#include "mmros/node/utility.hpp"
+
 #include <image_transport/image_transport.hpp>
 
 #include <glog/logging.h>
@@ -54,7 +56,7 @@ bool MultiCameraNode::onConnectForSingleCamera(
   const std::string & image_topic,
   const std::function<void(sensor_msgs::msg::Image::ConstSharedPtr)> & callback, bool use_raw)
 {
-  const auto image_qos = getTopicQos(use_raw ? image_topic : image_topic + "/compressed");
+  const auto image_qos = getTopicQos(this, use_raw ? image_topic : image_topic + "/compressed");
   if (image_qos) {
     rclcpp::SubscriptionOptions options;
     options.callback_group = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
@@ -70,15 +72,4 @@ bool MultiCameraNode::onConnectForSingleCamera(
     return false;
   }
 }
-
-std::optional<rclcpp::QoS> MultiCameraNode::getTopicQos(const std::string & query_topic)
-{
-  const auto publisher_info = get_publishers_info_by_topic(query_topic);
-  if (publisher_info.size() != 1) {
-    return std::nullopt;
-  } else {
-    return publisher_info[0].qos_profile();
-  }
-}
-
 }  // namespace mmros::node

--- a/mmros/src/node/single_camera_node.cpp
+++ b/mmros/src/node/single_camera_node.cpp
@@ -14,6 +14,8 @@
 
 #include "mmros/node/single_camera_node.hpp"
 
+#include "mmros/node/utility.hpp"
+
 #include <image_transport/image_transport.hpp>
 
 #include <glog/logging.h>
@@ -38,7 +40,7 @@ void SingleCameraNode::onConnect(
 
   const auto image_topic = resolve_topic_name("~/input/image");
 
-  const auto image_qos = getTopicQos(use_raw ? image_topic : image_topic + "/compressed");
+  const auto image_qos = getTopicQos(this, use_raw ? image_topic : image_topic + "/compressed");
   if (image_qos) {
     subscription_ = image_transport::create_subscription(
       this, image_topic, callback, use_raw ? "raw" : "compressed",
@@ -50,16 +52,6 @@ void SingleCameraNode::onConnect(
         get_logger(), "Successfully subscribed to %s, connection timer canceled",
         image_topic.c_str());
     }
-  }
-}
-
-std::optional<rclcpp::QoS> SingleCameraNode::getTopicQos(const std::string & query_topic)
-{
-  const auto publisher_info = get_publishers_info_by_topic(query_topic);
-  if (publisher_info.size() != 1) {
-    return std::nullopt;
-  } else {
-    return publisher_info[0].qos_profile();
   }
 }
 }  // namespace mmros::node


### PR DESCRIPTION
## Description

This pull request refactors how the QoS (Quality of Service) profile is retrieved for camera topics in both the `MultiCameraNode` and `SingleCameraNode` classes. The logic for getting the QoS profile has been moved into a new utility header, reducing code duplication and improving maintainability. The main changes are as follows:

**Refactoring and Code Deduplication**

* Introduced a new utility header file, `utility.hpp`, which provides a reusable `getTopicQos` function to retrieve the QoS profile for a given topic. This function is now used in both camera node classes.
* Removed the duplicated `getTopicQos` method implementations from both `MultiCameraNode` and `SingleCameraNode`, and updated their code to use the new utility function instead. [[1]](diffhunk://#diff-79492daad1bde08bf5cb614a0e5e383ef151b805090d6f1badb447c49790e732L59-R68) [[2]](diffhunk://#diff-381cd0f79ef22422a9b4603d9da1fad84035307f2641a14afca820da57ab5aa9L55-L63) [[3]](diffhunk://#diff-a5c69976b297f33b72dd749dcc6793777d3944d01707b1c5c76da20f593b1982L73-L83) [[4]](diffhunk://#diff-8434e7c34f274809fb11a92900129d8a3b7e2fa3474fd9d0796b60476100b09bL55-L64)

**Header and Include Cleanups**

* Updated the include directives in the relevant files to remove unused headers (such as `<optional>`) and to include the new utility header where needed. [[1]](diffhunk://#diff-79492daad1bde08bf5cb614a0e5e383ef151b805090d6f1badb447c49790e732L24) [[2]](diffhunk://#diff-381cd0f79ef22422a9b4603d9da1fad84035307f2641a14afca820da57ab5aa9L23) [[3]](diffhunk://#diff-a5c69976b297f33b72dd749dcc6793777d3944d01707b1c5c76da20f593b1982R17-R18) [[4]](diffhunk://#diff-8434e7c34f274809fb11a92900129d8a3b7e2fa3474fd9d0796b60476100b09bR17-R18)

**API Consistency**

* Modified calls to `getTopicQos` in both node implementations to pass the node pointer as required by the new utility function signature. [[1]](diffhunk://#diff-a5c69976b297f33b72dd749dcc6793777d3944d01707b1c5c76da20f593b1982L57-R59) [[2]](diffhunk://#diff-8434e7c34f274809fb11a92900129d8a3b7e2fa3474fd9d0796b60476100b09bL41-R43)

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
