### PR TITLE
Refactor/callback type alias

### DIFF
--- a/mmros/include/mmros/node/multi_camera_node.hpp
+++ b/mmros/include/mmros/node/multi_camera_node.hpp
@@ -32,6 +32,8 @@ namespace mmros::node
 class MultiCameraNode : public rclcpp::Node
 {
 public:
+  using Callback = image_transport::Subscriber::Callback;
+
   /**
    * @brief Constructor for MultiCameraNode.
    *
@@ -48,8 +50,7 @@ public:
    * @param use_raw Whether to use raw images or not.
    */
   void onConnect(
-    const std::vector<std::string> & image_topics,
-    const std::function<void(sensor_msgs::msg::Image::ConstSharedPtr)> & callback, bool use_raw);
+    const std::vector<std::string> & image_topics, const Callback & callback, bool use_raw);
 
 protected:
   rclcpp::TimerBase::SharedPtr connection_timer_;  //!< Topic connection timer.
@@ -64,8 +65,7 @@ private:
    * @return True if the connection was successful, false otherwise.
    */
   bool onConnectForSingleCamera(
-    const std::string & image_topic,
-    const std::function<void(sensor_msgs::msg::Image::ConstSharedPtr)> & callback, bool use_raw);
+    const std::string & image_topic, const Callback & callback, bool use_raw);
 
   std::vector<image_transport::Subscriber> subscriptions_;  //!< Subscribers for each camera topic.
 };

--- a/mmros/include/mmros/node/single_camera_node.hpp
+++ b/mmros/include/mmros/node/single_camera_node.hpp
@@ -30,6 +30,8 @@ namespace mmros::node
 class SingleCameraNode : public rclcpp::Node
 {
 public:
+  using Callback = image_transport::Subscriber::Callback;
+
   /**
    * @brief Construct a new SingleCameraNode object.
    *
@@ -44,8 +46,7 @@ public:
    * @param callback Callback function.
    * @param use_raw Indicates whether to use raw image.
    */
-  void onConnect(
-    const std::function<void(sensor_msgs::msg::Image::ConstSharedPtr)> & callback, bool use_raw);
+  void onConnect(const Callback & callback, bool use_raw);
 
 protected:
   rclcpp::TimerBase::SharedPtr connection_timer_;  //!< Topic connection timer.

--- a/mmros/src/node/multi_camera_node.cpp
+++ b/mmros/src/node/multi_camera_node.cpp
@@ -36,8 +36,7 @@ MultiCameraNode::MultiCameraNode(const std::string & name, const rclcpp::NodeOpt
 }
 
 void MultiCameraNode::onConnect(
-  const std::vector<std::string> & image_topics,
-  const std::function<void(sensor_msgs::msg::Image::ConstSharedPtr)> & callback, bool use_raw)
+  const std::vector<std::string> & image_topics, const Callback & callback, bool use_raw)
 {
   subscriptions_.clear();
 
@@ -53,8 +52,7 @@ void MultiCameraNode::onConnect(
 }
 
 bool MultiCameraNode::onConnectForSingleCamera(
-  const std::string & image_topic,
-  const std::function<void(sensor_msgs::msg::Image::ConstSharedPtr)> & callback, bool use_raw)
+  const std::string & image_topic, const Callback & callback, bool use_raw)
 {
   const auto image_qos = getTopicQos(this, use_raw ? image_topic : image_topic + "/compressed");
   if (image_qos) {

--- a/mmros/src/node/single_camera_node.cpp
+++ b/mmros/src/node/single_camera_node.cpp
@@ -31,8 +31,7 @@ SingleCameraNode::SingleCameraNode(const std::string & name, const rclcpp::NodeO
   google::InstallFailureSignalHandler();
 }
 
-void SingleCameraNode::onConnect(
-  const std::function<void(sensor_msgs::msg::Image::ConstSharedPtr)> & callback, bool use_raw)
+void SingleCameraNode::onConnect(const Callback & callback, bool use_raw)
 {
   auto resolve_topic_name = [this](const std::string & query) {
     return this->get_node_topics_interface()->resolve_topic_name(query);


### PR DESCRIPTION
## Description

This pull request refactors the callback type used for camera image subscriptions in both `MultiCameraNode` and `SingleCameraNode` classes to improve type safety and consistency. The main change is replacing generic `std::function` callbacks with the specific `image_transport::Subscriber::Callback` type.

**Callback type refactor:**

* Added a `Callback` type alias using `image_transport::Subscriber::Callback` to both `MultiCameraNode` and `SingleCameraNode` classes in their respective header files. [[1]](diffhunk://#diff-79492daad1bde08bf5cb614a0e5e383ef151b805090d6f1badb447c49790e732R35-R36) [[2]](diffhunk://#diff-381cd0f79ef22422a9b4603d9da1fad84035307f2641a14afca820da57ab5aa9R33-R34)
* Updated the signatures of `onConnect` and `onConnectForSingleCamera` methods in both header and source files to use the new `Callback` type alias instead of `std::function<void(sensor_msgs::msg::Image::ConstSharedPtr)>`. [[1]](diffhunk://#diff-79492daad1bde08bf5cb614a0e5e383ef151b805090d6f1badb447c49790e732L51-R53) [[2]](diffhunk://#diff-79492daad1bde08bf5cb614a0e5e383ef151b805090d6f1badb447c49790e732L67-R68) [[3]](diffhunk://#diff-a5c69976b297f33b72dd749dcc6793777d3944d01707b1c5c76da20f593b1982L39-R39) [[4]](diffhunk://#diff-a5c69976b297f33b72dd749dcc6793777d3944d01707b1c5c76da20f593b1982L56-R55) [[5]](diffhunk://#diff-381cd0f79ef22422a9b4603d9da1fad84035307f2641a14afca820da57ab5aa9L47-R49) [[6]](diffhunk://#diff-8434e7c34f274809fb11a92900129d8a3b7e2fa3474fd9d0796b60476100b09bL34-R34)

This change makes the callback interface more explicit and aligned with the underlying image transport library, reducing the risk of type mismatches.

These changes make the codebase more robust and consistent in how image callbacks are defined and invoked across all camera node types.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
