### PR TITLE
feat: add lidar node

### DIFF
--- a/mmros/include/mmros/node/lidar_node.hpp
+++ b/mmros/include/mmros/node/lidar_node.hpp
@@ -1,0 +1,58 @@
+// Copyright 2025 Kotaro Uetake.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MMROS__NODE__LIDAR_NODE_HPP_
+#define MMROS__NODE__LIDAR_NODE_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <sensor_msgs/msg/point_cloud2.hpp>
+
+#include <functional>
+#include <string>
+
+namespace mmros::node
+{
+/**
+ * @brief LidarNode class for subscribing to point cloud topic.
+ */
+class LidarNode : public rclcpp::Node
+{
+public:
+  using Callback = std::function<void(sensor_msgs::msg::PointCloud2::ConstSharedPtr)>;
+
+  /**
+   * @brief Constructor for LidarNode.
+   *
+   * @param name The name of the node.
+   * @param options The options for the node.
+   */
+  LidarNode(const std::string & name, const rclcpp::NodeOptions & options);
+
+  /**
+   * @brief Check node connection and start subscribing.
+   *
+   * @param callback Callback function.
+   */
+  void onConnect(const Callback & callback);
+
+protected:
+  rclcpp::TimerBase::SharedPtr connection_timer_;  //!< Topic connection timer.
+
+private:
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr
+    subscription_;  //!< PointCloud subscription.
+};
+}  // namespace mmros::node
+#endif  // MMROS__NODE__LIDAR_NODE_HPP_

--- a/mmros/include/mmros/node/utility.hpp
+++ b/mmros/include/mmros/node/utility.hpp
@@ -36,5 +36,17 @@ inline std::optional<rclcpp::QoS> getTopicQos(const rclcpp::Node * node, const s
   return publisher_info.size() != 1 ? std::nullopt
                                     : std::make_optional(publisher_info[0].qos_profile());
 }
+
+/**
+ * @brief Resolve a topic name.
+ *
+ * @param node The node to query.
+ * @param query The topic name to resolve.
+ * @return std::string The resolved topic name.
+ */
+inline std::string resolveTopicName(rclcpp::Node * node, const std::string & query)
+{
+  return node->get_node_topics_interface()->resolve_topic_name(query);
+}
 }  // namespace mmros::node
 #endif  // MMROS__NODE__UTILITY_HPP_

--- a/mmros/src/node/lidar_node.cpp
+++ b/mmros/src/node/lidar_node.cpp
@@ -1,0 +1,52 @@
+// Copyright 2025 Kotaro Uetake.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mmros/node/lidar_node.hpp"
+
+#include "mmros/node/utility.hpp"
+
+#include <glog/logging.h>
+
+#include <string>
+
+namespace mmros::node
+{
+LidarNode::LidarNode(const std::string & name, const rclcpp::NodeOptions & options)
+: rclcpp::Node(name, options)
+{
+  google::InitGoogleLogging(name.c_str());
+  google::InstallFailureSignalHandler();
+}
+
+void LidarNode::onConnect(const Callback & callback)
+{
+  const auto pointcloud_topic = resolveTopicName(this, "~/input/pointcloud");
+
+  const auto pointcloud_qos = getTopicQos(this, pointcloud_topic);
+  if (pointcloud_qos) {
+    subscription_ = create_subscription<sensor_msgs::msg::PointCloud2>(
+      pointcloud_topic, *pointcloud_qos, callback);
+
+    if (connection_timer_) {
+      connection_timer_->cancel();
+      RCLCPP_INFO(
+        get_logger(), "Successfully subscribed to %s, connection timer canceled",
+        pointcloud_topic.c_str());
+    }
+  } else {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 5000, "Failed to subscribe to %s", pointcloud_topic.c_str());
+  }
+}
+}  // namespace mmros::node


### PR DESCRIPTION
## Description

This pull request introduces a new `LidarNode` class for subscribing to point cloud topics in the `mmros::node` namespace, and adds supporting utility and implementation code. The main changes are grouped as follows:

**New LidarNode Implementation:**

* Added a new header file `lidar_node.hpp` defining the `LidarNode` class, which inherits from `rclcpp::Node` and provides methods for connecting to a point cloud topic and handling subscriptions.
* Implemented the `LidarNode` class in `lidar_node.cpp`, including initialization with Google Logging, and a connection method that resolves the topic name, retrieves QoS settings, and manages the subscription lifecycle.

**Utility Enhancements:**

* Added a `resolveTopicName` inline utility function in `utility.hpp` to resolve fully qualified topic names using a node instance.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
