### PR TITLE
refactor: replace resolveTopicName to utility function

### DIFF
--- a/mmros/src/node/single_camera_node.cpp
+++ b/mmros/src/node/single_camera_node.cpp
@@ -33,11 +33,7 @@ SingleCameraNode::SingleCameraNode(const std::string & name, const rclcpp::NodeO
 
 void SingleCameraNode::onConnect(const Callback & callback, bool use_raw)
 {
-  auto resolve_topic_name = [this](const std::string & query) {
-    return this->get_node_topics_interface()->resolve_topic_name(query);
-  };
-
-  const auto image_topic = resolve_topic_name("~/input/image");
+  const auto image_topic = resolveTopicName(this, "~/input/image");
 
   const auto image_qos = getTopicQos(this, use_raw ? image_topic : image_topic + "/compressed");
   if (image_qos) {


### PR DESCRIPTION
## Description

This pull request refactors the way topic names are resolved in the `SingleCameraNode` class to improve code clarity and maintainability. The main change is the replacement of a local lambda function with a direct call to a utility function.

Refactoring and code simplification:

* Replaced the local `resolve_topic_name` lambda with a call to the `resolveTopicName` utility function for resolving the `image_topic` in `SingleCameraNode::onConnect`, making the code more consistent and easier to maintain.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
