### PR TITLE
feat: add camera lidar node

### DIFF
--- a/mmros/include/mmros/node/camera_lidar_node.hpp
+++ b/mmros/include/mmros/node/camera_lidar_node.hpp
@@ -1,0 +1,86 @@
+// Copyright 2025 Kotaro Uetake.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MMROS__NODE__CAMERA_LIDAR_NODE_HPP_
+#define MMROS__NODE__CAMERA_LIDAR_NODE_HPP_
+
+#include <image_transport/subscriber.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <sensor_msgs/msg/point_cloud2.hpp>
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace mmros::node
+{
+/**
+ * @brief CameraLidarNode class for subscribing to multiple image topics and pointcloud topic.
+ */
+class CameraLidarNode : public rclcpp::Node
+{
+public:
+  using PointCloudCallback = std::function<void(sensor_msgs::msg::PointCloud2::ConstSharedPtr)>;
+  using ImageCallback = image_transport::Subscriber::Callback;
+
+  /**
+   * @brief Constructor for CameraLidarNode.
+   *
+   * @param name Name of the node.
+   * @param options Options for the node.
+   */
+  CameraLidarNode(const std::string & name, const rclcpp::NodeOptions & options);
+
+  /**
+   * @brief Connects the node to the pointcloud and image topics.
+   *
+   * @param pointcloud_callback Callback function for pointcloud messages.
+   * @param image_topics Vector of image topic names.
+   * @param image_callback Callback function for image messages.
+   * @param use_raw Whether to use raw image data.
+   */
+  void onConnect(
+    const PointCloudCallback & pointcloud_callback, const std::vector<std::string> & image_topics,
+    const ImageCallback & image_callback, bool use_raw);
+
+protected:
+  rclcpp::TimerBase::SharedPtr connection_timer_;  //!< Topic connection timer.
+
+private:
+  /**
+   * @brief Connect to a single pointcloud topic.
+   *
+   * @param callback Callback function to be called when a new pointcloud is received.
+   * @return True if the connection was successful, false otherwise.
+   */
+  bool onConnectLidar(const PointCloudCallback & pointcloud_callback);
+
+  /**
+   * @brief Connect to a single image topic.
+   *
+   * @param image_topic Image topic name.
+   * @param image_callback Callback function to be called when a new image is received.
+   * @param use_raw Whether to use raw images or not.
+   * @return True if the connection was successful, false otherwise.
+   */
+  bool onConnectForSingleCamera(
+    const std::string & image_topic, const ImageCallback & image_callback, bool use_raw);
+
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr
+    pointcloud_subscription_;  //!< Subscriber for pointcloud topic
+  std::vector<image_transport::Subscriber> image_subscriptions_;  //!< Subscribers for image topics
+};
+}  // namespace mmros::node
+#endif  // MMROS__NODE__CAMERA_LIDAR_NODE_HPP_

--- a/mmros/src/node/camera_lidar_node.cpp
+++ b/mmros/src/node/camera_lidar_node.cpp
@@ -1,0 +1,93 @@
+// Copyright 2025 Kotaro Uetake.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mmros/node/camera_lidar_node.hpp"
+
+#include "mmros/node/utility.hpp"
+
+#include <image_transport/image_transport.hpp>
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace mmros::node
+{
+CameraLidarNode::CameraLidarNode(const std::string & name, const rclcpp::NodeOptions & options)
+: rclcpp::Node(name, options)
+{
+  google::InitGoogleLogging(name.c_str());
+  google::InstallFailureSignalHandler();
+}
+
+void CameraLidarNode::onConnect(
+  const PointCloudCallback & pointcloud_callback, const std::vector<std::string> & image_topics,
+  const ImageCallback & image_callback, bool use_raw)
+{
+  image_subscriptions_.clear();
+
+  bool success =
+    onConnectLidar(pointcloud_callback) &&
+    std::all_of(image_topics.begin(), image_topics.end(), [&](const auto & image_topic) {
+      return onConnectForSingleCamera(image_topic, image_callback, use_raw);
+    });
+
+  if (success && connection_timer_) {
+    connection_timer_->cancel();
+    RCLCPP_INFO(
+      get_logger(), "Successfully connected to lidar and all cameras, connection timer canceled");
+  }
+}
+
+bool CameraLidarNode::onConnectLidar(const PointCloudCallback & pointcloud_callback)
+{
+  const auto pointcloud_topic = resolveTopicName(this, "~/input/pointcloud");
+
+  const auto pointcloud_qos = getTopicQos(this, pointcloud_topic);
+  if (pointcloud_qos) {
+    pointcloud_subscription_ = create_subscription<sensor_msgs::msg::PointCloud2>(
+      pointcloud_topic, *pointcloud_qos, pointcloud_callback);
+    return true;
+  } else {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 5000, "Failed to subscribe to %s", pointcloud_topic.c_str());
+    return false;
+  }
+}
+
+bool CameraLidarNode::onConnectForSingleCamera(
+  const std::string & image_topic, const ImageCallback & image_callback, bool use_raw)
+{
+  const auto image_qos = getTopicQos(this, use_raw ? image_topic : image_topic + "/compressed");
+  if (image_qos) {
+    rclcpp::SubscriptionOptions options;
+    options.callback_group = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+
+    const auto subscription = image_transport::create_subscription(
+      this, image_topic, image_callback, use_raw ? "raw" : "compressed",
+      image_qos->get_rmw_qos_profile(), options);
+
+    image_subscriptions_.emplace_back(std::move(subscription));
+    return true;
+  } else {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 5000, "Failed to create subscription for topic '%s'",
+      image_topic.c_str());
+    return false;
+  }
+}
+}  // namespace mmros::node


### PR DESCRIPTION
## Description

This pull request introduces a new `CameraLidarNode` class that provides an abstraction for subscribing to multiple image topics and a point cloud topic in a ROS2 environment. The implementation includes both the header and source files, with methods for connecting to topics and managing subscriptions. The code also adds appropriate copyright and license information.

**New Node Implementation:**

* Added `CameraLidarNode` class in `mmros/include/mmros/node/camera_lidar_node.hpp` to manage connections to multiple camera image topics and a lidar point cloud topic, including public APIs for connecting and handling callbacks.
* Implemented the logic for subscribing to point cloud and image topics, including error handling and use of QoS profiles, in `mmros/src/node/camera_lidar_node.cpp`.

**Licensing and Documentation:**

* Added Apache 2.0 license and documentation comments to both the header and source files for clarity and compliance. [[1]](diffhunk://#diff-42d1c522c08e076282474ef50f00eda964d69da847d87c80e9e3494f31c5ad74R1-R86) [[2]](diffhunk://#diff-c4c8a8f587606cfd1b333e9dedf718247ed2ee6b4eb5c4308b380409b889e2b2R1-R93)

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
