### PR TITLE
chore: make default workspace size larger

### DIFF
--- a/mmros/include/mmros/tensorrt/utility.hpp
+++ b/mmros/include/mmros/tensorrt/utility.hpp
@@ -56,7 +56,7 @@ struct TrtCommonConfig
    */
   explicit TrtCommonConfig(
     const std::string onnx_path, const std::string precision = "fp32",
-    const std::string engine_path = "", const size_t max_workspace_size = (1ULL << 30U),
+    const std::string engine_path = "", const size_t max_workspace_size = (1ULL << 60U),
     const int32_t dla_core_id = -1, const bool profile_per_layer = false)
   : onnx_path(onnx_path),
     precision(precision),


### PR DESCRIPTION
## Description

This pull request makes a single change to the `TrtCommonConfig` struct in the `mmros/include/mmros/tensorrt/utility.hpp` file. The maximum workspace size default value has been significantly increased.

* Increased the default `max_workspace_size` from 1GB (`1ULL << 30U`) to 1 exabyte (`1ULL << 60U`) in the `TrtCommonConfig` constructor.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
