### PR TITLE
feat: add a new project for EoMT

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ ROS 2 support of [OpenMMLab](https://openmmlab.com/) projects using TensorRT.
 |                       | Camera   | [DEIMv2 (ArXiv'2025)](./docs/projects/deimv2.md)                   |
 | Semantic Segmentation | Camera   | [Mask2Former (CVPR'2022)](./docs/projects/mask2former.md)          |
 |                       | Camera   | [PIDNet (ArXiv'2022)](./docs/projects/pidnet.md)                   |
+|                       | Camera   | [EoMT (CVPR'2025)](./docs/projects/eomt.md)                        |
 | Instance Segmentation | Camera   | [Instance RTMDet (ArXiv'2022)](./docs/projects/instance_rtmdet.md) |
 | Panoptic Segmentation | Camera   | [Panoptic FPN (CVPR'2019)](./docs/projects/panoptic_fpn.md)        |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,7 @@ ROS 2 support of [OpenMMLab](https://openmmlab.com/) projects using TensorRT.
 |                       | Camera   | [DEIMv2 (ArXiv'2025)](./projects/deimv2.md)                   |
 | Semantic Segmentation | Camera   | [Mask2Former (CVPR'2022)](./projects/mask2former.md)          |
 |                       | Camera   | [PIDNet (ArXiv'2022)](./projects/pidnet.md)                   |
+|                       | Camera   | [EoMT (CVPR'2025)](./projects/eomt.md)                        |
 | Instance Segmentation | Camera   | [Instance RTMDet (ArXiv'2022)](./projects/instance_rtmdet.md) |
 | Panoptic Segmentation | Camera   | [Panoptic FPN (CVPR'2019)](./projects/panoptic_fpn.md)        |
 

--- a/docs/projects/eomt.md
+++ b/docs/projects/eomt.md
@@ -1,0 +1,43 @@
+# EoMT
+
+For the details of the model configuration and results, please refer to [here](https://github.com/ktro2828/eomt).
+
+## ONNX Models
+
+| Backbone | Input Shape |                                                        Config                                                        | Checkpoint |                                               ONNX                                                |
+| :------: | :---------: | :------------------------------------------------------------------------------------------------------------------: | :--------: | :-----------------------------------------------------------------------------------------------: |
+|  DinoV2  | 3x1024x1024 | [config](https://github.com/ktro2828/eomt/blob/develop/onnx/configs/dinov2/cityscapes/semantic/eomt_large_1024.yaml) |    N/A     | [1x3x1024x1024](https://drive.google.com/uc?export=download&id=1cHOfOysS0grYzazHQwD_GogF1bWpJMOq) |
+
+## Inference Times
+
+<!-- Please describe inference time of the model using trtexec. -->
+
+| Backbone |  Input Shape  | Precision |  Device  | Median Enqueue Time (ms) |
+| :------: | :-----------: | :-------: | :------: | :----------------------: |
+|  DinoV2  | 1x3x1024x1024 |   FP32    | RTX 3060 |          2.177           |
+
+## Custom TensorRT Plugins
+
+<!-- Please describe custom TensorRT plugins. -->
+
+N/A
+
+## Inputs & Outputs in ROS 2
+
+### Inputs
+
+|     Topic      |           Type           | Description  |
+| :------------: | :----------------------: | :----------: |
+| `/input/image` | `/sensor_msgs/msg/Image` | Input image. |
+
+### Outputs
+
+|     Topic      |           Type           |        Description        |
+| :------------: | :----------------------: | :-----------------------: |
+| `/output/mask` | `/sensor_msgs/msg/Image` | Output segmentation mask. |
+
+## How to Run
+
+```shell
+ros2 launch eomt eomt.launch.xml
+```

--- a/projects/eomt/CMakeLists.txt
+++ b/projects/eomt/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.14)
+project(eomt)
+
+# -------- default to C++17 --------
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+# -------- create compile_commands.json --------
+if(NOT CMAKE_EXPORT_COMPILE_COMMANDS)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+endif()
+
+# -------- find dependencies --------
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+# -------- testing --------
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+# -------- install --------
+ament_auto_package(INSTALL_TO_SHARE launch config
+                   data)

--- a/projects/eomt/README.md
+++ b/projects/eomt/README.md
@@ -1,0 +1,1 @@
+../../docs/projects/eomt.md

--- a/projects/eomt/config/eomt.param.yaml
+++ b/projects/eomt/config/eomt.param.yaml
@@ -1,0 +1,8 @@
+/**:
+  ros__parameters:
+    tensorrt:
+      onnx_path: $(var directory/onnx)/eomt_large_semantic_cisyscapes-static-1024x1024.onnx
+      precision: fp32
+    detector:
+      mean: [0.0, 0.0, 0.0]
+      std: [1.0, 1.0, 1.0]

--- a/projects/eomt/launch/eomt.launch.xml
+++ b/projects/eomt/launch/eomt.launch.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <arg name="file/parameter" default="$(find-pkg-share eomt)/config/eomt.param.yaml" description="Path to the parameter file"/>
+  <arg name="directory/onnx" default="$(find-pkg-share eomt)/data" description="Path to the ONNX model directory"/>
+
+  <arg name="input/image" default="input/image" description="Input image topic"/>
+  <arg name="output/mask" default="output/mask" description="Output mask topic"/>
+  <arg name="use_raw" default="false" description="Use raw image"/>
+  <arg name="build_only" default="false" description="Build only"/>
+
+  <arg name="visualize" default="true" description="Visualize output masks"/>
+
+  <group>
+    <push-ros-namespace namespace="eomt"/>
+    <node pkg="mmros" exec="mmros_semantic_segmentation2d_exe" name="detector" output="screen">
+      <param from="$(var file/parameter)" allow_substs="true"/>
+      <remap from="~/input/image" to="$(var input/image)"/>
+      <remap from="~/output/mask" to="$(var output/mask)"/>
+      <param name="use_raw" value="$(var use_raw)"/>
+      <param name="build_only" value="$(var build_only)"/>
+    </node>
+
+    <group if="$(var visualize)">
+      <node pkg="mmrviz" exec="segmentation2d_visualizer_exe" output="screen">
+        <param name="use_raw" value="$(var use_raw)"/>
+        <remap from="~/input/image" to="$(var input/image)"/>
+        <remap from="~/input/mask" to="$(var output/mask)"/>
+      </node>
+    </group>
+  </group>
+</launch>

--- a/projects/eomt/package.xml
+++ b/projects/eomt/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>eomt</name>
+  <version>0.0.0</version>
+  <description>The ROS 2 package for EoMT.</description>
+  <maintainer email="kotaro.uetake@tier4.jp">ktro2828</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <exec_depend>mmros</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
## Description

This pull request introduces a new ROS 2 package for EoMT, including all necessary configuration, launch, and documentation files to support semantic segmentation using the DinoV2 backbone. The package is set up for easy integration, deployment, and testing within a ROS 2 environment.

**New Package Setup and Configuration:**

* Added a new ROS 2 package definition for `eomt`, specifying dependencies, maintainer, and licensing in `package.xml`.
* Introduced a `CMakeLists.txt` to configure the build system, enforce C++17, enable compile commands, and set up testing and installation.
* Added a parameter YAML file (`config/eomt.param.yaml`) specifying model and detector parameters, including ONNX path, precision, and normalization values.

**Launch and Integration:**

* Created a launch file (`launch/eomt.launch.xml`) to start the segmentation node and optional visualization, with parameter and topic remapping support.

**Documentation:**

* Added a comprehensive documentation file (`docs/projects/eomt.md`) detailing model configuration, ONNX model links, inference times, ROS 2 topics, and usage instructions.
* Linked the documentation in the package README.

## How was this PR tested?

```shell
ros2 launch eomt eomt.launch.xml input/image:=/nuscenes/CAM_FRONT/image
```

<img width="1684" height="869" alt="Screenshot from 2025-09-28 09-10-45" src="https://github.com/user-attachments/assets/62f206b1-be80-4bb1-81fb-c2adb94f7f5e" />

## Notes for reviewers

None.

## Effects on system behavior

None.
