### PR TITLE
refactor: update parameter names

### DIFF
--- a/projects/deimv2/config/deimv2.param.yaml
+++ b/projects/deimv2/config/deimv2.param.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     tensorrt:
-      onnx_path: $(var data_path)/deimv2_dinov3_l_coco-static-640x640.onnx
+      onnx_path: $(var directory/onnx)/deimv2_dinov3_l_coco-static-640x640.onnx
       precision: fp32
     detector:
       mean: [123.675, 116.28, 103.53]

--- a/projects/deimv2/launch/deimv2.launch.xml
+++ b/projects/deimv2/launch/deimv2.launch.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <arg name="param_path" default="$(find-pkg-share deimv2)/config/deimv2.param.yaml"/>
-  <arg name="data_path" default="$(find-pkg-share deimv2)/data"/>
+  <arg name="file/parameter" default="$(find-pkg-share deimv2)/config/deimv2.param.yaml" description="Path to the parameter file"/>
+  <arg name="directory/onnx" default="$(find-pkg-share deimv2)/data" description="Path to the ONNX model directory"/>
 
-  <arg name="input/image" default="input/image"/>
-  <arg name="output/boxes" default="output/boxes"/>
-  <arg name="use_raw" default="false"/>
-  <arg name="build_only" default="false"/>
+  <arg name="input/image" default="input/image" description="Input image topic"/>
+  <arg name="output/boxes" default="output/boxes" description="Output boxes topic"/>
+  <arg name="use_raw" default="false" description="Use raw image data"/>
+  <arg name="build_only" default="false" description="Build only"/>
 
-  <arg name="visualize" default="true"/>
+  <arg name="visualize" default="true" description="Visualize output boxes"/>
 
   <group>
     <push-ros-namespace namespace="deimv2"/>
     <node pkg="mmros" exec="mmros_detection2d_exe" name="detector" output="screen">
-      <param from="$(var param_path)" allow_substs="true"/>
+      <param from="$(var file/parameter)" allow_substs="true"/>
       <remap from="~/input/image" to="$(var input/image)"/>
       <remap from="~/output/boxes" to="$(var output/boxes)"/>
       <param name="use_raw" value="$(var use_raw)"/>

--- a/projects/detr/config/detr.param.yaml
+++ b/projects/detr/config/detr.param.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     tensorrt:
-      onnx_path: $(var data_path)/detr_r50_8xb2-150e_coco-static-800x1344.onnx
+      onnx_path: $(var directory/onnx)/detr_r50_8xb2-150e_coco-static-800x1344.onnx
       precision: fp32
     detector:
       mean: [123.675, 116.28, 103.53]

--- a/projects/detr/launch/detr.launch.xml
+++ b/projects/detr/launch/detr.launch.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <arg name="param_path" default="$(find-pkg-share detr)/config/detr.param.yaml"/>
-  <arg name="data_path" default="$(find-pkg-share detr)/data"/>
+  <arg name="file/parameter" default="$(find-pkg-share detr)/config/detr.param.yaml" description="Path to the parameter file"/>
+  <arg name="directory/onnx" default="$(find-pkg-share detr)/data" description="Path to the ONNX model directory"/>
 
-  <arg name="input/image" default="input/image"/>
-  <arg name="output/boxes" default="output/boxes"/>
-  <arg name="use_raw" default="false"/>
-  <arg name="build_only" default="false"/>
+  <arg name="input/image" default="input/image" description="Input image topic"/>
+  <arg name="output/boxes" default="output/boxes" description="Output boxes topic"/>
+  <arg name="use_raw" default="false" description="Use raw image data"/>
+  <arg name="build_only" default="false" description="Build only"/>
 
-  <arg name="visualize" default="true"/>
+  <arg name="visualize" default="true" description="Visualize output boxes"/>
 
   <group>
     <push-ros-namespace namespace="detr"/>
     <node pkg="mmros" exec="mmros_detection2d_exe" name="detector" output="screen">
-      <param from="$(var param_path)" allow_substs="true"/>
+      <param from="$(var file/parameter)" allow_substs="true"/>
       <remap from="~/input/image" to="$(var input/image)"/>
       <remap from="~/output/boxes" to="$(var output/boxes)"/>
       <param name="use_raw" value="$(var use_raw)"/>

--- a/projects/instance_rtmdet/config/instance_rtmdet.param.yaml
+++ b/projects/instance_rtmdet/config/instance_rtmdet.param.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     tensorrt:
-      onnx_path: $(var data_path)/rtmdet-ins_x_8xb16-300e_coco-static-640x640.onnx
+      onnx_path: $(var directory/onnx)/rtmdet-ins_x_8xb16-300e_coco-static-640x640.onnx
       precision: fp32
     detector:
       mean: [123.675, 116.28, 103.53]

--- a/projects/instance_rtmdet/launch/instance_rtmdet.launch.xml
+++ b/projects/instance_rtmdet/launch/instance_rtmdet.launch.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <arg name="param_path" default="$(find-pkg-share instance_rtmdet)/config/instance_rtmdet.param.yaml"/>
-  <arg name="data_path" default="$(find-pkg-share instance_rtmdet)/data"/>
+  <arg name="file/parameter" default="$(find-pkg-share instance_rtmdet)/config/instance_rtmdet.param.yaml" description="Path to the parameter file"/>
+  <arg name="directory/onnx" default="$(find-pkg-share instance_rtmdet)/data" description="Path to the ONNX model directory"/>
 
-  <arg name="input/image" default="input/image"/>
-  <arg name="output/segments" default="output/segments"/>
-  <arg name="use_raw" default="false"/>
-  <arg name="build_only" default="false"/>
+  <arg name="input/image" default="input/image" description="Input image topic"/>
+  <arg name="output/segments" default="output/segments" description="Output segments topic"/>
+  <arg name="use_raw" default="false" description="Use raw image"/>
+  <arg name="build_only" default="false" description="Build only"/>
 
-  <arg name="visualize" default="true"/>
+  <arg name="visualize" default="true" description="Visualize output segments"/>
 
   <group>
     <push-ros-namespace namespace="instance_rtmdet"/>
     <node pkg="mmros" exec="mmros_instance_segmentation2d_exe" name="detector" output="screen">
-      <param from="$(var param_path)" allow_substs="true"/>
+      <param from="$(var file/parameter)" allow_substs="true"/>
       <remap from="~/input/image" to="$(var input/image)"/>
       <remap from="~/output/segments" to="$(var output/segments)"/>
       <param name="use_raw" value="$(var use_raw)"/>

--- a/projects/mask2former/config/mask2former.param.yaml
+++ b/projects/mask2former/config/mask2former.param.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     tensorrt:
-      onnx_path: $(var data_path)/mask2former_r50_8xb2-90k_cityscapes-static-512x1024.onnx
+      onnx_path: $(var directory/onnx)/mask2former_r50_8xb2-90k_cityscapes-static-512x1024.onnx
       precision: fp32
     detector:
       mean: [123.675, 116.28, 103.53]

--- a/projects/mask2former/launch/mask2former.launch.xml
+++ b/projects/mask2former/launch/mask2former.launch.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <arg name="param_path" default="$(find-pkg-share mask2former)/config/mask2former.param.yaml"/>
-  <arg name="data_path" default="$(find-pkg-share mask2former)/data"/>
+  <arg name="file/parameter" default="$(find-pkg-share mask2former)/config/mask2former.param.yaml" description="Path to the parameter file"/>
+  <arg name="directory/onnx" default="$(find-pkg-share mask2former)/data" description="Path to the ONNX model directory"/>
 
-  <arg name="input/image" default="input/image"/>
-  <arg name="output/mask" default="output/mask"/>
-  <arg name="use_raw" default="false"/>
-  <arg name="build_only" default="false"/>
+  <arg name="input/image" default="input/image" description="Input image topic"/>
+  <arg name="output/mask" default="output/mask" description="Output mask topic"/>
+  <arg name="use_raw" default="false" description="Use raw image"/>
+  <arg name="build_only" default="false" description="Build only"/>
 
-  <arg name="visualize" default="true"/>
+  <arg name="visualize" default="true" description="Visualize output masks"/>
 
   <group>
     <push-ros-namespace namespace="mask2former"/>
     <node pkg="mmros" exec="mmros_semantic_segmentation2d_exe" name="detector" output="screen">
-      <param from="$(var param_path)" allow_substs="true"/>
+      <param from="$(var file/parameter)" allow_substs="true"/>
       <remap from="~/input/image" to="$(var input/image)"/>
       <remap from="~/output/mask" to="$(var output/mask)"/>
       <param name="use_raw" value="$(var use_raw)"/>

--- a/projects/panoptic_fpn/config/panoptic_fpn.param.yaml
+++ b/projects/panoptic_fpn/config/panoptic_fpn.param.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     tensorrt:
-      onnx_path: $(var data_path)/panoptic_fpn_r50_fpn_1x_coco-static-800x1344.onnx
+      onnx_path: $(var directory/onnx)/panoptic_fpn_r50_fpn_1x_coco-static-800x1344.onnx
       precision: fp32
     detector:
       mean: [123.675, 116.28, 103.53]

--- a/projects/panoptic_fpn/launch/panoptic_fpn.launch.xml
+++ b/projects/panoptic_fpn/launch/panoptic_fpn.launch.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <arg name="param_path" default="$(find-pkg-share panoptic_fpn)/config/panoptic_fpn.param.yaml"/>
-  <arg name="data_path" default="$(find-pkg-share panoptic_fpn)/data"/>
+  <arg name="file/parameter" default="$(find-pkg-share panoptic_fpn)/config/panoptic_fpn.param.yaml" description="Path to the parameter file"/>
+  <arg name="directory/onnx" default="$(find-pkg-share panoptic_fpn)/data" description="Path to the ONNX model directory"/>
 
-  <arg name="input/image" default="input/image"/>
-  <arg name="output/boxes" default="output/boxes"/>
-  <arg name="output/semantic_mask" default="output/semantic_mask"/>
-  <arg name="use_raw" default="false"/>
-  <arg name="build_only" default="false"/>
+  <arg name="input/image" default="input/image" description="Input image topic"/>
+  <arg name="output/boxes" default="output/boxes" description="Output bounding boxes topic"/>
+  <arg name="output/semantic_mask" default="output/semantic_mask" description="Output semantic mask topic"/>
+  <arg name="use_raw" default="false" description="Use raw image"/>
+  <arg name="build_only" default="false" description="Build only"/>
 
-  <arg name="visualize" default="true"/>
+  <arg name="visualize" default="true" description="Visualize output boxes and masks"/>
 
   <group>
     <push-ros-namespace namespace="panoptic_fpn"/>
     <node pkg="mmros" exec="mmros_panoptic_segmentation2d_exe" name="detector" output="screen">
-      <param from="$(var param_path)" allow_substs="true"/>
+      <param from="$(var file/parameter)" allow_substs="true"/>
       <remap from="~/input/image" to="$(var input/image)"/>
       <remap from="~/output/boxes" to="$(var output/boxes)"/>
       <remap from="~/output/semantic_mask" to="$(var output/semantic_mask)"/>

--- a/projects/pidnet/config/pidnet.param.yaml
+++ b/projects/pidnet/config/pidnet.param.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     tensorrt:
-      onnx_path: $(var data_path)/pidnet-l_2xb6-120k_cityscapes-static-1024x1024.onnx
+      onnx_path: $(var directory/onnx)/pidnet-l_2xb6-120k_cityscapes-static-1024x1024.onnx
       precision: fp32
     detector:
       mean: [123.675, 116.28, 103.53]

--- a/projects/pidnet/launch/pidnet.launch.xml
+++ b/projects/pidnet/launch/pidnet.launch.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <arg name="param_path" default="$(find-pkg-share pidnet)/config/pidnet.param.yaml"/>
-  <arg name="data_path" default="$(find-pkg-share pidnet)/data"/>
+  <arg name="file/parameter" default="$(find-pkg-share pidnet)/config/pidnet.param.yaml" description="Path to the parameter file"/>
+  <arg name="directory/onnx" default="$(find-pkg-share pidnet)/data" description="Path to the ONNX model directory"/>
 
-  <arg name="input/image" default="input/image"/>
-  <arg name="output/mask" default="output/mask"/>
-  <arg name="use_raw" default="false"/>
-  <arg name="build_only" default="false"/>
+  <arg name="input/image" default="input/image" description="Input image topic"/>
+  <arg name="output/mask" default="output/mask" description="Output mask topic"/>
+  <arg name="use_raw" default="false" description="Use raw image"/>
+  <arg name="build_only" default="false" description="Build only"/>
 
-  <arg name="visualize" default="true"/>
+  <arg name="visualize" default="true" description="Visualize output masks"/>
 
   <group>
     <push-ros-namespace namespace="pidnet"/>
     <node pkg="mmros" exec="mmros_semantic_segmentation2d_exe" name="detector" output="screen">
-      <param from="$(var param_path)" allow_substs="true"/>
+      <param from="$(var file/parameter)" allow_substs="true"/>
       <remap from="~/input/image" to="$(var input/image)"/>
       <remap from="~/output/mask" to="$(var output/mask)"/>
       <param name="use_raw" value="$(var use_raw)"/>

--- a/projects/rfdetr/config/rfdetr.param.yaml
+++ b/projects/rfdetr/config/rfdetr.param.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     tensorrt:
-      onnx_path: $(var data_path)/rfdetr-base-static_560x560.onnx
+      onnx_path: $(var directory/onnx)/rfdetr-base-static_560x560.onnx
       precision: fp32
     detector:
       mean: [124.16, 116.77, 103.94]

--- a/projects/rfdetr/launch/rfdetr.launch.xml
+++ b/projects/rfdetr/launch/rfdetr.launch.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <arg name="param_path" default="$(find-pkg-share rfdetr)/config/rfdetr.param.yaml"/>
-  <arg name="data_path" default="$(find-pkg-share rfdetr)/data"/>
+  <arg name="file/parameter" default="$(find-pkg-share rfdetr)/config/rfdetr.param.yaml" description="Path to the parameter file"/>
+  <arg name="directory/onnx" default="$(find-pkg-share rfdetr)/data" description="Path to the ONNX model directory"/>
 
-  <arg name="input/image" default="input/image"/>
-  <arg name="output/boxes" default="output/boxes"/>
-  <arg name="use_raw" default="false"/>
-  <arg name="build_only" default="false"/>
+  <arg name="input/image" default="input/image" description="Input image topic"/>
+  <arg name="output/boxes" default="output/boxes" description="Output bounding boxes topic"/>
+  <arg name="use_raw" default="false" description="Use raw image data"/>
+  <arg name="build_only" default="false" description="Build only"/>
 
-  <arg name="visualize" default="true"/>
+  <arg name="visualize" default="true" description="Visualize output boxes"/>
 
   <group>
     <push-ros-namespace namespace="rfdetr"/>
     <node pkg="mmros" exec="mmros_detection2d_exe" name="detector" output="screen">
-      <param from="$(var param_path)" allow_substs="true"/>
+      <param from="$(var file/parameter)" allow_substs="true"/>
       <remap from="~/input/image" to="$(var input/image)"/>
       <remap from="~/output/boxes" to="$(var output/boxes)"/>
       <param name="use_raw" value="$(var use_raw)"/>

--- a/projects/rtmdet/config/rtmdet.param.yaml
+++ b/projects/rtmdet/config/rtmdet.param.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     tensorrt:
-      onnx_path: $(var data_path)/rtmdet_x_8xb32-300e_coco-static-640x640.onnx
+      onnx_path: $(var directory/onnx)/rtmdet_x_8xb32-300e_coco-static-640x640.onnx
       precision: fp32
     detector:
       mean: [123.675, 116.28, 103.53]

--- a/projects/rtmdet/launch/rtmdet.launch.xml
+++ b/projects/rtmdet/launch/rtmdet.launch.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <arg name="param_path" default="$(find-pkg-share rtmdet)/config/rtmdet.param.yaml"/>
-  <arg name="data_path" default="$(find-pkg-share rtmdet)/data"/>
+  <arg name="file/parameter" default="$(find-pkg-share rtmdet)/config/rtmdet.param.yaml" description="Path to the parameter file"/>
+  <arg name="directory/onnx" default="$(find-pkg-share rtmdet)/data" description="Path to the ONNX model directory"/>
 
-  <arg name="input/image" default="input/image"/>
-  <arg name="output/boxes" default="output/boxes"/>
-  <arg name="use_raw" default="false"/>
-  <arg name="build_only" default="false"/>
+  <arg name="input/image" default="input/image" description="Input image topic"/>
+  <arg name="output/boxes" default="output/boxes" description="Output bounding boxes topic"/>
+  <arg name="use_raw" default="false" description="Use raw image data"/>
+  <arg name="build_only" default="false" description="Build only"/>
 
-  <arg name="visualize" default="true"/>
+  <arg name="visualize" default="true" description="Visualize output boxes"/>
 
   <group>
     <push-ros-namespace namespace="rtmdet"/>
     <node pkg="mmros" exec="mmros_detection2d_exe" name="detector" output="screen">
-      <param from="$(var param_path)" allow_substs="true"/>
+      <param from="$(var file/parameter)" allow_substs="true"/>
       <remap from="~/input/image" to="$(var input/image)"/>
       <remap from="~/output/boxes" to="$(var output/boxes)"/>
       <param name="use_raw" value="$(var use_raw)"/>

--- a/projects/yolox/config/yolox.param.yaml
+++ b/projects/yolox/config/yolox.param.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     tensorrt:
-      onnx_path: $(var data_path)/yolox_l_8x8_300e_coco-static-640x640.onnx
+      onnx_path: $(var directory/onnx)/yolox_l_8x8_300e_coco-static-640x640.onnx
       precision: fp32
     detector:
       mean: [0.0, 0.0, 0.0]

--- a/projects/yolox/launch/yolox.launch.xml
+++ b/projects/yolox/launch/yolox.launch.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <arg name="param_path" default="$(find-pkg-share yolox)/config/yolox.param.yaml"/>
-  <arg name="data_path" default="$(find-pkg-share yolox)/data"/>
+  <arg name="file/parameter" default="$(find-pkg-share yolox)/config/yolox.param.yaml" description="Path to the parameter file"/>
+  <arg name="directory/onnx" default="$(find-pkg-share yolox)/data" description="Path to the ONNX model directory"/>
 
-  <arg name="input/image" default="input/image"/>
-  <arg name="output/boxes" default="output/boxes"/>
-  <arg name="use_raw" default="false"/>
-  <arg name="build_only" default="false"/>
+  <arg name="input/image" default="input/image" description="Input image topic"/>
+  <arg name="output/boxes" default="output/boxes" description="Output bounding boxes topic"/>
+  <arg name="use_raw" default="false" description="Use raw image data"/>
+  <arg name="build_only" default="false" description="Build only"/>
 
-  <arg name="visualize" default="true"/>
+  <arg name="visualize" default="true" description="Visualize output boxes"/>
 
   <group>
     <push-ros-namespace namespace="yolox"/>
     <node pkg="mmros" exec="mmros_detection2d_exe" name="detector" output="screen">
-      <param from="$(var param_path)" allow_substs="true"/>
+      <param from="$(var file/parameter)" allow_substs="true"/>
       <remap from="~/input/image" to="$(var input/image)"/>
       <remap from="~/output/boxes" to="$(var output/boxes)"/>
       <param name="use_raw" value="$(var use_raw)"/>


### PR DESCRIPTION
## Description

This pull request refactors the way ONNX model paths and parameter files are handled across multiple project configurations and launch files. The main goal is to standardize variable names and improve clarity by replacing generic path variables with more descriptive ones, and by adding helpful descriptions to launch arguments.

Key changes include:

- Replacing the use of `data_path` with `directory/onnx` for specifying ONNX model directories in parameter files.
- Updating launch files to use `file/parameter` and `directory/onnx` argument names, along with adding descriptions for better readability and maintainability.
- Ensuring all launch files and parameter files across projects follow this new convention.

The most important changes are:

**Standardization of ONNX Model Path Variables:**
- All parameter YAML files now use `$(var directory/onnx)` instead of `$(var data_path)` to specify the ONNX model location, improving clarity and consistency for model directory references. [[1]](diffhunk://#diff-4894a67cee456f7ee25ef95d9c6d34919a7051b2fdc87cbc2b596985ea31aec4L4-R4) [[2]](diffhunk://#diff-e6adb309ef71af34a22cb6fbc679652a56bfd5e3560a0adbd1706ea3462ca3aaL4-R4) [[3]](diffhunk://#diff-ab2466960064aae47155d6bf54579303f3f17d67a87e6f5e33d7ada09d9ebae5L4-R4) [[4]](diffhunk://#diff-1ece439b9c65c60da7ca7411adbfaf020818697fab691eddf089eddc44a2015bL4-R4) [[5]](diffhunk://#diff-3eacacd7e55f5eda3df49cd30abf0784da74e17839a4579e16fa0edbc6844247L4-R4) [[6]](diffhunk://#diff-54eb1ff03fa4527fabc2764e45b0233836af5ad9f2fa0a26094243d961adb617L4-R4) [[7]](diffhunk://#diff-b35ab2eb035f6b7ccbf8e9a7fb7fd6801554c439837e7a87ee541ac967ddb272L4-R4) [[8]](diffhunk://#diff-0253861009d4760499b3f1907cdbb9d6200fbd9efa2da46b45406ce04441102cL4-R4) [[9]](diffhunk://#diff-527da31a7b7d0c05adbf47f870ce234b59073f17b5f30edccf9732f65e3bdae7L4-R4)

**Refactoring and Documentation of Launch Arguments:**
- Launch files now use `file/parameter` and `directory/onnx` as argument names instead of `param_path` and `data_path`, and each argument is supplemented with a clear description, making the launch files more user-friendly and self-documenting. [[1]](diffhunk://#diff-bd9a4ae00552ae53813509916471a49d2ca6641345a470c34808cb0f2880205cL3-R16) [[2]](diffhunk://#diff-6ae5dbf7340c22c52d58562527ffc733865ea32c0b89cce5724da9fe4df34008L3-R16) [[3]](diffhunk://#diff-751d2be3e111eac2ef49935473f3256de75861da6295ee52233bfad69724606aL3-R16) [[4]](diffhunk://#diff-7a03a752dfae3b5e73fbb71f2320d2856e4ce694ffc4ef5540534f467399b62aL3-R16) [[5]](diffhunk://#diff-4df4a5b37eded771e6f1c15f590d0cb6f14f93d42549571e4686ffc3874b2a50L3-R17) [[6]](diffhunk://#diff-4bef3dae02054fad8a6dce973d2eded963af51433ea3a2fe477a28c9a4918706L3-R16) [[7]](diffhunk://#diff-a3c0a3cba37a621e515456a8d2c4c720d82d32b0799c4164cfeaf3d61d45e386L3-R16) [[8]](diffhunk://#diff-5f3657e69493018afbccf304ef5dc59668e48015785945d513fe2c440159d300L3-R16) [[9]](diffhunk://#diff-2eceab25559fa7dcab901ae97ec1058dc715cb1462180a4148496be7af229d49L3-R16)

**Consistent Parameter Passing in Launch Files:**
- All `<param from=...>` tags in launch files now reference `$(var file/parameter)` instead of the old variable, ensuring consistency in how parameter files are loaded. [[1]](diffhunk://#diff-bd9a4ae00552ae53813509916471a49d2ca6641345a470c34808cb0f2880205cL3-R16) [[2]](diffhunk://#diff-6ae5dbf7340c22c52d58562527ffc733865ea32c0b89cce5724da9fe4df34008L3-R16) [[3]](diffhunk://#diff-751d2be3e111eac2ef49935473f3256de75861da6295ee52233bfad69724606aL3-R16) [[4]](diffhunk://#diff-7a03a752dfae3b5e73fbb71f2320d2856e4ce694ffc4ef5540534f467399b62aL3-R16) [[5]](diffhunk://#diff-4df4a5b37eded771e6f1c15f590d0cb6f14f93d42549571e4686ffc3874b2a50L3-R17) [[6]](diffhunk://#diff-4bef3dae02054fad8a6dce973d2eded963af51433ea3a2fe477a28c9a4918706L3-R16) [[7]](diffhunk://#diff-a3c0a3cba37a621e515456a8d2c4c720d82d32b0799c4164cfeaf3d61d45e386L3-R16) [[8]](diffhunk://#diff-5f3657e69493018afbccf304ef5dc59668e48015785945d513fe2c440159d300L3-R16) [[9]](diffhunk://#diff-2eceab25559fa7dcab901ae97ec1058dc715cb1462180a4148496be7af229d49L3-R16)

**Improved Argument Documentation:**
- All launch arguments (such as input/output topics, `use_raw`, `build_only`, `visualize`) now include descriptions, making it easier for users to understand their purpose. [[1]](diffhunk://#diff-bd9a4ae00552ae53813509916471a49d2ca6641345a470c34808cb0f2880205cL3-R16) [[2]](diffhunk://#diff-6ae5dbf7340c22c52d58562527ffc733865ea32c0b89cce5724da9fe4df34008L3-R16) [[3]](diffhunk://#diff-751d2be3e111eac2ef49935473f3256de75861da6295ee52233bfad69724606aL3-R16) [[4]](diffhunk://#diff-7a03a752dfae3b5e73fbb71f2320d2856e4ce694ffc4ef5540534f467399b62aL3-R16) [[5]](diffhunk://#diff-4df4a5b37eded771e6f1c15f590d0cb6f14f93d42549571e4686ffc3874b2a50L3-R17) [[6]](diffhunk://#diff-4bef3dae02054fad8a6dce973d2eded963af51433ea3a2fe477a28c9a4918706L3-R16) [[7]](diffhunk://#diff-a3c0a3cba37a621e515456a8d2c4c720d82d32b0799c4164cfeaf3d61d45e386L3-R16) [[8]](diffhunk://#diff-5f3657e69493018afbccf304ef5dc59668e48015785945d513fe2c440159d300L3-R16) [[9]](diffhunk://#diff-2eceab25559fa7dcab901ae97ec1058dc715cb1462180a4148496be7af229d49L3-R16)

These changes collectively improve maintainability, readability, and usability of the configuration and launch files across all supported projects.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
