### PR TITLE
fix: modify data type of output segmentation mask to int64_t

### DIFF
--- a/mmros/include/mmros/detector/semantic_segmenter2d.hpp
+++ b/mmros/include/mmros/detector/semantic_segmenter2d.hpp
@@ -101,7 +101,7 @@ private:
   int64_t in_height_;                     //!< Model input height.
   int64_t in_width_;                      //!< Model input width.
 
-  cuda::CudaUniquePtr<int[]> output_d_;  //!< Output mask pointer on the device. [B, 1, H, W].
+  cuda::CudaUniquePtr<int64_t[]> output_d_;  //!< Output mask pointer on the device. [B, 1, H, W].
 };
 }  // namespace mmros::detector
 #endif  // MMROS__DETECTOR__SEMANTIC_SEGMENTER2D_HPP_


### PR DESCRIPTION
## Description

This pull request updates the `SemanticSegmenter2D` class to handle output masks as `int64_t` (64-bit integers) instead of `int` (typically 32-bit), ensuring consistency in data types across CUDA device memory, host memory, and postprocessing. It also updates the way output masks are converted for use with OpenCV.

**Data type consistency and memory handling:**

* Changed the device output pointer `output_d_` in `SemanticSegmenter2D` from `int[]` to `int64_t[]` to ensure the output mask uses 64-bit integers throughout the CUDA pipeline.
* Updated CUDA memory allocation and memory copy operations to use `int64_t` instead of `int`, both in device memory allocation (`cuda::make_unique<int64_t[]>`) and host-side vectors (`std::vector<int64_t>`), and adjusted the `cudaMemcpy` size accordingly. [[1]](diffhunk://#diff-2ccc22aa135b5b818470220e8a19afa74f69dc3538fd35d7c3da0894a60b45f8L138-R142) [[2]](diffhunk://#diff-2ccc22aa135b5b818470220e8a19afa74f69dc3538fd35d7c3da0894a60b45f8L205-R228)

**Postprocessing and OpenCV compatibility:**

* Refactored the postprocessing step to convert `int64_t` class IDs to `unsigned char` when creating OpenCV `cv::Mat` masks, replacing the previous method of casting a vector and using `memcpy` with an explicit per-element conversion loop. This ensures correct conversion and avoids issues with direct memory reinterpretation.

**Code hygiene:**

* Added additional standard library headers (`<chrono>`, `<map>`, `<sstream>`, `<thread>`) to `semantic_segmenter2d.cpp`, likely for future use or consistency.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
