### PR TITLE
docs: update documents

### DIFF
--- a/docs/projects/README.md
+++ b/docs/projects/README.md
@@ -31,9 +31,9 @@ Edit your launch file, which is `projects/my_project/launch/my_project.launch.xm
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <!-- Model parameters and onnx file path -->
-  <arg name="param_path" default="$(find-pkg-share my_project)/config/my_project.param.yaml"/>
-  <arg name="data_path" default="$(find-pkg-share my_project)/data"/>
+  <!-- Model parameters and ONNX file path -->
+  <arg name="file/parameter" default="$(find-pkg-share my_project)/config/my_project.param.yaml"/>
+  <arg name="directory/onnx" default="$(find-pkg-share my_project)/data"/>
 
   <!-- I/O topic names -->
   <arg name="input/image" default="input/image"/>
@@ -52,7 +52,7 @@ Edit your launch file, which is `projects/my_project/launch/my_project.launch.xm
     <push-ros-namespace namespace="my_project"/>
     <!-- Detector node -->
     <node pkg="mmros" exec="mmros_detection2d_exe" name="detector" output="screen">
-      <param from="$(var param_path)" allow_substs="true"/>
+      <param from="$(var file/parameter)" allow_substs="true"/>
       <remap from="~/input/image" to="$(var input/image)"/>
       <remap from="~/output/boxes" to="$(var output/boxes)"/>
       <param name="use_raw" value="$(var use_raw)"/>
@@ -77,8 +77,8 @@ Edit your parameter file, which is `projects/my_project/config/my_config.param.y
 /**:
   ros__parameters:
     tensorrt:
-      onnx_path: $(var data_path)/my_project.onnx
-      precision: fp32
+      onnx_path: $(var directory/onnx)/my_project.onnx
+      precision: fp32 # [fp32, fp16, int8]
     detector:
       mean: [0.0, 0.0, 0.0]
       std: [1.0, 1.0, 1.0]

--- a/docs/projects/deimv2.md
+++ b/docs/projects/deimv2.md
@@ -12,7 +12,7 @@ For the details of the model configuration and results, please refer to [here](h
 
 | Backbone | Input Shape | Precision |  Device  | Median Enqueue Time (ms) |
 | :------: | :---------: | :-------: | :------: | :----------------------: |
-|  DinoV3  | 1x3x640x640 |   FP32    | RTX 3060 |          3.098           |
+|  DinoV3  | 1x3x640x640 |   FP32    | RTX 3060 |          32.278          |
 
 ## Custom TensorRT Plugins
 

--- a/docs/projects/eomt.md
+++ b/docs/projects/eomt.md
@@ -14,7 +14,7 @@ For the details of the model configuration and results, please refer to [here](h
 
 | Backbone |  Input Shape  | Precision |  Device  | Median Enqueue Time (ms) |
 | :------: | :-----------: | :-------: | :------: | :----------------------: |
-|  DinoV2  | 1x3x1024x1024 |   FP32    | RTX 3060 |          2.177           |
+|  DinoV2  | 1x3x1024x1024 |   FP32    | RTX 3060 |         734.257          |
 
 ## Custom TensorRT Plugins
 


### PR DESCRIPTION
## Description

This pull request updates documentation and configuration for the `my_project` ROS package, focusing on parameter naming consistency and correcting performance metrics in the documentation. The most important changes are grouped below:

Parameter and Path Naming Consistency:

* Updated argument names in the launch file example in `docs/projects/README.md` to use more descriptive and consistent names (`file/parameter` and `directory/onnx` instead of `param_path` and `data_path`).
* Updated the parameter passing in the launch file node definition to match the new argument names.
* Updated the parameter file example to use the new `directory/onnx` variable for the ONNX path and clarified the allowed values for the `precision` parameter.

Documentation Corrections:

* Corrected the reported median enqueue time for the DinoV3 backbone in `docs/projects/deimv2.md` from `3.098 ms` to `32.278 ms`.
* Corrected the reported median enqueue time for the DinoV2 backbone in `docs/projects/eomt.md` from `2.177 ms` to `734.257 ms`.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
