### PR TITLE
fix: resolve compilation error for invalid constexpr in C++17

### DIFF
--- a/mmros/include/mmros/tensorrt/utility.hpp
+++ b/mmros/include/mmros/tensorrt/utility.hpp
@@ -27,6 +27,7 @@ namespace fs = ::std::experimental::filesystem;
 #endif
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
## Description

This pull request introduces a minor update to the `mmros/include/mmros/tensorrt/utility.hpp` header file. The change adds the `<array>` header to the set of included libraries, likely to support usage of `std::array` in the file.

* Added `<array>` to the list of included headers in `utility.hpp` to enable use of fixed-size arrays.

## How was this PR tested?

Confirm the building succeeded.

## Notes for reviewers

None.

## Effects on system behavior

None.
