### PR TITLE
refactor: avoid to allocate device memory for mean and std in every loop

### DIFF
--- a/mmros/include/mmros/detector/detector2d.hpp
+++ b/mmros/include/mmros/detector/detector2d.hpp
@@ -38,8 +38,25 @@ namespace mmros::detector
  */
 struct Detector2dConfig
 {
-  std::vector<double> mean;           //!< Image mean.
-  std::vector<double> std;            //!< Image std.
+  Detector2dConfig(
+    const std::vector<double> & _mean, const std::vector<double> & _std,
+    archetype::BoxFormat2D _box_format, double _score_threshold)
+  : box_format(_box_format), score_threshold(_score_threshold)
+  {
+    std::vector<float> mean_h(_mean.begin(), _mean.end());
+    std::vector<float> std_h(_std.begin(), _std.end());
+    mean = cuda::make_unique<float[]>(mean_h.size());
+    std = cuda::make_unique<float[]>(std_h.size());
+
+    CHECK_CUDA_ERROR(
+      ::cudaMemcpy(
+        mean.get(), mean_h.data(), mean_h.size() * sizeof(float), cudaMemcpyHostToDevice));
+    CHECK_CUDA_ERROR(
+      ::cudaMemcpy(std.get(), std_h.data(), std_h.size() * sizeof(float), cudaMemcpyHostToDevice));
+  }
+
+  cuda::CudaUniquePtr<float[]> mean;  //!< Image mean on device.
+  cuda::CudaUniquePtr<float[]> std;   //!< Image std on device.
   archetype::BoxFormat2D box_format;  //!< Box format.
   double score_threshold;             //!< Score threshold.
 };
@@ -59,8 +76,7 @@ public:
    * @param trt_config TensorRT common config.
    * @param detector_config Detector config.
    */
-  explicit Detector2D(
-    const tensorrt::TrtCommonConfig & trt_config, const Detector2dConfig & detector_config);
+  explicit Detector2D(tensorrt::TrtCommonConfig && trt_config, Detector2dConfig && detector_config);
 
   /**
    * @brief Execute inference using input images. Returns `std::nullopt` if the inference fails.

--- a/mmros/include/mmros/detector/instance_segmenter2d.hpp
+++ b/mmros/include/mmros/detector/instance_segmenter2d.hpp
@@ -34,8 +34,25 @@ namespace mmros::detector
  */
 struct InstanceSegmenter2dConfig
 {
-  std::vector<double> mean;           //!< Image mean.
-  std::vector<double> std;            //!< Image std.
+  InstanceSegmenter2dConfig(
+    const std::vector<double> & _mean, const std::vector<double> & _std,
+    archetype::BoxFormat2D _box_format, double _score_threshold)
+  : box_format(_box_format), score_threshold(_score_threshold)
+  {
+    std::vector<float> mean_h(_mean.begin(), _mean.end());
+    std::vector<float> std_h(_std.begin(), _std.end());
+    mean = cuda::make_unique<float[]>(mean_h.size());
+    std = cuda::make_unique<float[]>(std_h.size());
+
+    CHECK_CUDA_ERROR(
+      ::cudaMemcpy(
+        mean.get(), mean_h.data(), mean_h.size() * sizeof(float), cudaMemcpyHostToDevice));
+    CHECK_CUDA_ERROR(
+      ::cudaMemcpy(std.get(), std_h.data(), std_h.size() * sizeof(float), cudaMemcpyHostToDevice));
+  }
+
+  cuda::CudaUniquePtr<float[]> mean;  //!< Image mean on device.
+  cuda::CudaUniquePtr<float[]> std;   //!< Image std on device.
   archetype::BoxFormat2D box_format;  //!< Box format.
   double score_threshold;             //!< Score threshold.
 };
@@ -57,8 +74,7 @@ public:
    * @param detector_config
    */
   InstanceSegmenter2D(
-    const tensorrt::TrtCommonConfig & trt_config,
-    const InstanceSegmenter2dConfig & detector_config);
+    tensorrt::TrtCommonConfig && trt_config, InstanceSegmenter2dConfig && detector_config);
 
   /**
    * @brief Execute inference using input images.

--- a/mmros/src/detector/detector2d.cpp
+++ b/mmros/src/detector/detector2d.cpp
@@ -40,11 +40,10 @@ namespace mmros::detector
 {
 using outputs_type = Detector2D::outputs_type;
 
-Detector2D::Detector2D(
-  const tensorrt::TrtCommonConfig & trt_config, const Detector2dConfig & detector_config)
+Detector2D::Detector2D(tensorrt::TrtCommonConfig && trt_config, Detector2dConfig && detector_config)
 {
-  trt_common_ = std::make_unique<tensorrt::TrtCommon>(trt_config);
-  detector_config_ = std::make_unique<Detector2dConfig>(detector_config);
+  trt_common_ = std::make_unique<tensorrt::TrtCommon>(std::move(trt_config));
+  detector_config_ = std::make_unique<Detector2dConfig>(std::move(detector_config));
 
   const auto network_input_dims = trt_common_->getTensorShape(0);
   const auto batch_size = network_input_dims.d[0];
@@ -184,22 +183,9 @@ void Detector2D::preprocess(const std::vector<cv::Mat> & images)
       images[0].cols * images[0].rows * 3 * batch_size * sizeof(unsigned char),
       ::cudaMemcpyHostToDevice, stream_));
 
-  // TODO(ktro2828): Refactoring not to load mean/std array every loop
-  std::vector<float> mean_h(detector_config_->mean.begin(), detector_config_->mean.end());
-  std::vector<float> std_h(detector_config_->std.begin(), detector_config_->std.end());
-  auto mean_d = cuda::make_unique<float[]>(mean_h.size());
-  auto std_d = cuda::make_unique<float[]>(std_h.size());
-
-  CHECK_CUDA_ERROR(
-    ::cudaMemcpyAsync(
-      mean_d.get(), mean_h.data(), mean_h.size() * sizeof(float), cudaMemcpyHostToDevice, stream_));
-  CHECK_CUDA_ERROR(
-    ::cudaMemcpyAsync(
-      std_d.get(), std_h.data(), std_h.size() * sizeof(float), cudaMemcpyHostToDevice, stream_));
-
   process::resize_bilinear_letterbox_nhwc_to_nchw32_batch_gpu(
     input_d_.get(), img_buf_d.get(), in_width_, in_height_, 3, images[0].cols, images[0].rows, 3,
-    batch_size, mean_d.get(), std_d.get(), stream_);
+    batch_size, detector_config_->mean.get(), detector_config_->std.get(), stream_);
 
   CHECK_CUDA_ERROR(cudaGetLastError());
 }

--- a/mmros/src/detector/instance_segmeter2d.cpp
+++ b/mmros/src/detector/instance_segmeter2d.cpp
@@ -44,10 +44,10 @@ namespace mmros::detector
 using outputs_type = InstanceSegmenter2D::outputs_type;
 
 InstanceSegmenter2D::InstanceSegmenter2D(
-  const tensorrt::TrtCommonConfig & trt_config, const InstanceSegmenter2dConfig & detector_config)
+  tensorrt::TrtCommonConfig && trt_config, InstanceSegmenter2dConfig && detector_config)
 {
-  trt_common_ = std::make_unique<tensorrt::TrtCommon>(trt_config);
-  detector_config_ = std::make_unique<InstanceSegmenter2dConfig>(detector_config);
+  trt_common_ = std::make_unique<tensorrt::TrtCommon>(std::move(trt_config));
+  detector_config_ = std::make_unique<InstanceSegmenter2dConfig>(std::move(detector_config));
 
   const auto network_input_dims = trt_common_->getTensorShape(0);
   const auto batch_size = network_input_dims.d[0];
@@ -190,22 +190,9 @@ void InstanceSegmenter2D::preprocess(const std::vector<cv::Mat> & images)
       images[0].cols * images[0].rows * 3 * batch_size * sizeof(unsigned char),
       ::cudaMemcpyHostToDevice, stream_));
 
-  // TODO(ktro2828): Refactoring not to load mean/std array every loop
-  std::vector<float> mean_h(detector_config_->mean.begin(), detector_config_->mean.end());
-  std::vector<float> std_h(detector_config_->std.begin(), detector_config_->std.end());
-  auto mean_d = cuda::make_unique<float[]>(mean_h.size());
-  auto std_d = cuda::make_unique<float[]>(std_h.size());
-
-  CHECK_CUDA_ERROR(
-    ::cudaMemcpyAsync(
-      mean_d.get(), mean_h.data(), mean_h.size() * sizeof(float), cudaMemcpyHostToDevice, stream_));
-  CHECK_CUDA_ERROR(
-    ::cudaMemcpyAsync(
-      std_d.get(), std_h.data(), std_h.size() * sizeof(float), cudaMemcpyHostToDevice, stream_));
-
   process::resize_bilinear_letterbox_nhwc_to_nchw32_batch_gpu(
     input_d_.get(), img_buf_d.get(), in_width_, in_height_, 3, images[0].cols, images[0].rows, 3,
-    batch_size, mean_d.get(), std_d.get(), stream_);
+    batch_size, detector_config_->mean.get(), detector_config_->std.get(), stream_);
 
   CHECK_CUDA_ERROR(cudaGetLastError());
 }

--- a/mmros/src/detector/semantic_segmenter2d.cpp
+++ b/mmros/src/detector/semantic_segmenter2d.cpp
@@ -41,10 +41,10 @@ namespace mmros::detector
 using outputs_type = SemanticSegmenter2D::outputs_type;
 
 SemanticSegmenter2D::SemanticSegmenter2D(
-  const tensorrt::TrtCommonConfig & trt_config, const SemanticSegmenter2dConfig & detector_config)
+  tensorrt::TrtCommonConfig && trt_config, SemanticSegmenter2dConfig && detector_config)
 {
-  trt_common_ = std::make_unique<tensorrt::TrtCommon>(trt_config);
-  detector_config_ = std::make_unique<SemanticSegmenter2dConfig>(detector_config);
+  trt_common_ = std::make_unique<tensorrt::TrtCommon>(std::move(trt_config));
+  detector_config_ = std::make_unique<SemanticSegmenter2dConfig>(std::move(detector_config));
 
   const auto network_input_dims = trt_common_->getTensorShape(0);
   const auto batch_size = network_input_dims.d[0];
@@ -174,22 +174,9 @@ void SemanticSegmenter2D::preprocess(const std::vector<cv::Mat> & images)
       images[0].cols * images[0].rows * 3 * batch_size * sizeof(unsigned char),
       ::cudaMemcpyHostToDevice, stream_));
 
-  // TODO(ktro2828): Refactoring not to load mean/std array every loop
-  std::vector<float> mean_h(detector_config_->mean.begin(), detector_config_->mean.end());
-  std::vector<float> std_h(detector_config_->std.begin(), detector_config_->std.end());
-  auto mean_d = cuda::make_unique<float[]>(mean_h.size());
-  auto std_d = cuda::make_unique<float[]>(std_h.size());
-
-  CHECK_CUDA_ERROR(
-    ::cudaMemcpyAsync(
-      mean_d.get(), mean_h.data(), mean_h.size() * sizeof(float), cudaMemcpyHostToDevice, stream_));
-  CHECK_CUDA_ERROR(
-    ::cudaMemcpyAsync(
-      std_d.get(), std_h.data(), std_h.size() * sizeof(float), cudaMemcpyHostToDevice, stream_));
-
   process::resize_bilinear_letterbox_nhwc_to_nchw32_batch_gpu(
     input_d_.get(), img_buf_d.get(), in_width_, in_height_, 3, images[0].cols, images[0].rows, 3,
-    batch_size, mean_d.get(), std_d.get(), stream_);
+    batch_size, detector_config_->mean.get(), detector_config_->std.get(), stream_);
 
   CHECK_CUDA_ERROR(cudaGetLastError());
 }


### PR DESCRIPTION
## Description

This pull request refactors the configuration and preprocessing logic for all 2D detector and segmenter classes to improve efficiency and clarity. The main change is moving the image normalization parameters (`mean` and `std`) to device memory once during configuration construction, rather than reloading and copying them on every preprocessing call. Additionally, constructors now use move semantics for configuration objects, ensuring better resource management.

**Configuration and Device Memory Improvements:**

* Refactored all config structs (`Detector2dConfig`, `InstanceSegmenter2dConfig`, `PanopticSegmenter2dConfig`, `SemanticSegmenter2dConfig`) to upload `mean` and `std` arrays to device memory in their constructors, replacing host-side vectors with device pointers (`CudaUniquePtr<float[]>`). This avoids repeated device memory allocations and copies during preprocessing. [[1]](diffhunk://#diff-611073c9ae62dce587ec7b0561c22c78051890f4e9b7377279eb2e52a19dbc37L41-R59) [[2]](diffhunk://#diff-125637157667947407eefdc7f89e997f5ae58d95bb8c016aee20e576b2174df0L37-R55) [[3]](diffhunk://#diff-433a0b51e9b329dbe54be833ab9ce295bdd9e59b96b2b6a5ae6bef1e20d262a0L39-R57) [[4]](diffhunk://#diff-67d28a0bef1e53cf08fdaf2256d454efce574a7d3282fe09426acd5c0cca1effL38-R53)

**Constructor and Resource Management Updates:**

* Updated all detector and segmenter class constructors to accept configuration objects via move semantics (`&&`), and store them using `std::move`, ensuring efficient resource transfer and ownership. [[1]](diffhunk://#diff-611073c9ae62dce587ec7b0561c22c78051890f4e9b7377279eb2e52a19dbc37L62-R79) [[2]](diffhunk://#diff-125637157667947407eefdc7f89e997f5ae58d95bb8c016aee20e576b2174df0L60-R77) [[3]](diffhunk://#diff-433a0b51e9b329dbe54be833ab9ce295bdd9e59b96b2b6a5ae6bef1e20d262a0L62-R79) [[4]](diffhunk://#diff-67d28a0bef1e53cf08fdaf2256d454efce574a7d3282fe09426acd5c0cca1effL58-R72) [[5]](diffhunk://#diff-3c42c7f2b5e0409ab29b675cdaa8c1bc7681544e03030e7684cb6c10bcd02105L43-R46) [[6]](diffhunk://#diff-49a7ef98e722eb7ad22af45979109245e1c6dd4a494a9460adfc2cf275d956ceL47-R50) [[7]](diffhunk://#diff-082137242d88fc2d4aebb9b3cdb88e3716482c3c209d38728a9aaf77fa41413fL42-R45) [[8]](diffhunk://#diff-2ccc22aa135b5b818470220e8a19afa74f69dc3538fd35d7c3da0894a60b45f8L44-R47)

**Preprocessing Efficiency:**

* Simplified the `preprocess` methods in all detector and segmenter classes to use the device-side `mean` and `std` arrays directly, removing redundant host-to-device memory operations and related temporary allocations. [[1]](diffhunk://#diff-3c42c7f2b5e0409ab29b675cdaa8c1bc7681544e03030e7684cb6c10bcd02105L187-R188) [[2]](diffhunk://#diff-49a7ef98e722eb7ad22af45979109245e1c6dd4a494a9460adfc2cf275d956ceL193-R195) [[3]](diffhunk://#diff-082137242d88fc2d4aebb9b3cdb88e3716482c3c209d38728a9aaf77fa41413fL201-R203) [[4]](diffhunk://#diff-2ccc22aa135b5b818470220e8a19afa74f69dc3538fd35d7c3da0894a60b45f8L177-R179)

## How was this PR tested?

- [x] Confirmed build passed
- [x] Confirmed some projects worked including `yolox`, `deimv2`, `pidnet`, `eomt`

## Notes for reviewers

None.

## Effects on system behavior

None.
