### PR TITLE
refactor: apply snake_case to the function names

### DIFF
--- a/mmros/include/mmros/archetype/exception.hpp
+++ b/mmros/include/mmros/archetype/exception.hpp
@@ -65,7 +65,7 @@ public:
    *
    * @param error `MmRosError` object.
    */
-  explicit MmRosException(const MmRosError & error) : error_(error) { appendMessagePrefix(); }
+  explicit MmRosException(const MmRosError & error) : error_(error) { append_message_prefix(); }
 
   /**
    * @brief Construct a new MmRosException object with error kind and message.
@@ -75,7 +75,7 @@ public:
    */
   MmRosException(const MmRosError_t & kind, const std::string & msg) : error_(kind, msg)
   {
-    appendMessagePrefix();
+    append_message_prefix();
   }
 
   /**
@@ -87,7 +87,7 @@ private:
   /**
    * @brief Append prefix to the error message depending on its kind.
    */
-  void appendMessagePrefix() noexcept
+  void append_message_prefix() noexcept
   {
     switch (error_.kind) {
       case MmRosError_t::TENSORRT:

--- a/mmros/include/mmros/archetype/result.hpp
+++ b/mmros/include/mmros/archetype/result.hpp
@@ -48,14 +48,14 @@ public:
   /**
    * @brief Check whether holding value is expected type.
    */
-  bool isOk() const noexcept { return std::holds_alternative<T>(value_); }
+  bool is_ok() const noexcept { return std::holds_alternative<T>(value_); }
 
   /**
    * @brief Return the expected value if it holds, otherwise throw `MmRosException`.
    */
   T unwrap() const
   {
-    if (isOk()) {
+    if (is_ok()) {
       return std::get<T>(value_);
     } else {
       throw MmRosException(std::get<MmRosError>(value_));
@@ -74,7 +74,7 @@ private:
  */
 
 template <typename T>
-Result<T> Ok(const T & value) noexcept
+Result<T> make_ok(const T & value) noexcept
 {
   return Result<T>(value);
 }
@@ -86,7 +86,7 @@ Result<T> Ok(const T & value) noexcept
  * @param error `MmRosError` object.
  */
 template <typename T>
-Result<T> Err(const MmRosError & error) noexcept
+Result<T> make_err(const MmRosError & error) noexcept
 {
   return Result<T>(error);
 }
@@ -98,7 +98,7 @@ Result<T> Err(const MmRosError & error) noexcept
  * @param kind Error kind.
  */
 template <typename T>
-Result<T> Err(const MmRosError_t & kind) noexcept
+Result<T> make_err(const MmRosError_t & kind) noexcept
 {
   MmRosError error(kind);
   return Result<T>(error);
@@ -112,7 +112,7 @@ Result<T> Err(const MmRosError_t & kind) noexcept
  * @param msg Error message.
  */
 template <typename T>
-Result<T> Err(const MmRosError_t & kind, const std::string & msg) noexcept
+Result<T> make_err(const MmRosError_t & kind, const std::string & msg) noexcept
 {
   MmRosError error(kind, msg);
   return Result<T>(error);

--- a/mmros/src/detector/detector2d.cpp
+++ b/mmros/src/detector/detector2d.cpp
@@ -77,21 +77,21 @@ archetype::Result<outputs_type> Detector2D::doInference(
   const std::vector<cv::Mat> & images) noexcept
 {
   if (images.empty()) {
-    return archetype::Err<outputs_type>(archetype::MmRosError_t::UNKNOWN, "No image.");
+    return archetype::make_err<outputs_type>(archetype::MmRosError_t::UNKNOWN, "No image.");
   }
 
   // 1. Init CUDA pointers
   try {
     initCudaPtr(images.size());
   } catch (const archetype::MmRosException & e) {
-    return archetype::Err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
+    return archetype::make_err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
   }
 
   // 2. Execute preprocess
   try {
     preprocess(images);
   } catch (const archetype::MmRosException & e) {
-    return archetype::Err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
+    return archetype::make_err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
   }
 
   // 3. Set tensors
@@ -99,14 +99,14 @@ archetype::Result<outputs_type> Detector2D::doInference(
   if (!trt_common_->setTensorsAddresses(buffers)) {
     std::ostringstream os;
     os << "@" << __FILE__ << ", #F:" << __FUNCTION__ << ", #L:" << __LINE__;
-    return archetype::Err<outputs_type>(archetype::MmRosError_t::TENSORRT, os.str());
+    return archetype::make_err<outputs_type>(archetype::MmRosError_t::TENSORRT, os.str());
   }
 
   // 4. Execute inference
   if (!trt_common_->enqueueV3(stream_)) {
     std::ostringstream os;
     os << "@" << __FILE__ << ", #F:" << __FUNCTION__ << ", #L:" << __LINE__;
-    return archetype::Err<outputs_type>(archetype::MmRosError_t::TENSORRT, os.str());
+    return archetype::make_err<outputs_type>(archetype::MmRosError_t::TENSORRT, os.str());
   }
 
   // 5. Execute postprocess
@@ -184,7 +184,7 @@ archetype::Result<outputs_type> Detector2D::postprocess(
         sizeof(int) * batch_size * num_detection * class_dim, ::cudaMemcpyDeviceToHost, stream_));
     CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
   } catch (const archetype::MmRosException & e) {
-    return archetype::Err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
+    return archetype::make_err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
   }
 
   outputs_type output;
@@ -210,6 +210,6 @@ archetype::Result<outputs_type> Detector2D::postprocess(
     output.push_back(std::move(boxes));
   }
 
-  return archetype::Ok(output);
+  return archetype::make_ok(output);
 }
 }  // namespace mmros::detector

--- a/mmros/src/detector/panoptic_segmenter2d.cpp
+++ b/mmros/src/detector/panoptic_segmenter2d.cpp
@@ -76,21 +76,21 @@ archetype::Result<outputs_type> PanopticSegmenter2D::doInference(
   const std::vector<cv::Mat> & images) noexcept
 {
   if (images.empty()) {
-    return archetype::Err<outputs_type>(archetype::MmRosError_t::UNKNOWN, "No image.");
+    return archetype::make_err<outputs_type>(archetype::MmRosError_t::UNKNOWN, "No image.");
   }
 
   // 1. Init CUDA pointers
   try {
     initCudaPtr(images.size());
   } catch (const archetype::MmRosException & e) {
-    return archetype::Err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
+    return archetype::make_err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
   }
 
   // 2. Execute preprocess
   try {
     preprocess(images);
   } catch (const archetype::MmRosException & e) {
-    return archetype::Err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
+    return archetype::make_err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
   }
 
   // 3. Set tensors
@@ -100,14 +100,14 @@ archetype::Result<outputs_type> PanopticSegmenter2D::doInference(
   if (!trt_common_->setTensorsAddresses(buffers)) {
     std::ostringstream os;
     os << "@" << __FILE__ << ", #F:" << __FUNCTION__ << ", #L:" << __LINE__;
-    return archetype::Err<outputs_type>(archetype::MmRosError_t::TENSORRT, os.str());
+    return archetype::make_err<outputs_type>(archetype::MmRosError_t::TENSORRT, os.str());
   }
 
   // 4. Execute inference
   if (!trt_common_->enqueueV3(stream_)) {
     std::ostringstream os;
     os << "@" << __FILE__ << ", #F:" << __FUNCTION__ << ", #L:" << __LINE__;
-    return archetype::Err<outputs_type>(archetype::MmRosError_t::TENSORRT, os.str());
+    return archetype::make_err<outputs_type>(archetype::MmRosError_t::TENSORRT, os.str());
   }
 
   // 5. Execute postprocess
@@ -216,7 +216,7 @@ archetype::Result<outputs_type> PanopticSegmenter2D::postprocess(
         ::cudaMemcpyDeviceToHost, stream_));
     CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
   } catch (const archetype::MmRosException & e) {
-    return archetype::Err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
+    return archetype::make_err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
   }
 
   outputs_type output;
@@ -248,6 +248,6 @@ archetype::Result<outputs_type> PanopticSegmenter2D::postprocess(
     output.emplace_back(std::move(boxes), std::move(mask));
   }
 
-  return archetype::Ok(output);
+  return archetype::make_ok(output);
 }
 }  // namespace mmros::detector

--- a/mmros/src/detector/semantic_segmenter2d.cpp
+++ b/mmros/src/detector/semantic_segmenter2d.cpp
@@ -78,21 +78,21 @@ archetype::Result<outputs_type> SemanticSegmenter2D::doInference(
   const std::vector<cv::Mat> & images) noexcept
 {
   if (images.empty()) {
-    return archetype::Err<outputs_type>(archetype::MmRosError_t::UNKNOWN, "No image.");
+    return archetype::make_err<outputs_type>(archetype::MmRosError_t::UNKNOWN, "No image.");
   }
 
   // 1. Init CUDA pointers
   try {
     initCudaPtr(images.size());
   } catch (const archetype::MmRosException & e) {
-    return archetype::Err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
+    return archetype::make_err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
   }
 
   // 2. Execute preprocess
   try {
     preprocess(images);
   } catch (const archetype::MmRosException & e) {
-    return archetype::Err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
+    return archetype::make_err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
   }
 
   // 3. Set tensors
@@ -100,14 +100,14 @@ archetype::Result<outputs_type> SemanticSegmenter2D::doInference(
   if (!trt_common_->setTensorsAddresses(buffers)) {
     std::ostringstream os;
     os << "@" << __FILE__ << ", #F:" << __FUNCTION__ << ", #L:" << __LINE__;
-    return archetype::Err<outputs_type>(archetype::MmRosError_t::TENSORRT, os.str());
+    return archetype::make_err<outputs_type>(archetype::MmRosError_t::TENSORRT, os.str());
   }
 
   // 4. Execute inference
   if (!trt_common_->enqueueV3(stream_)) {
     std::ostringstream os;
     os << "@" << __FILE__ << ", #F:" << __FUNCTION__ << ", #L:" << __LINE__;
-    return archetype::Err<outputs_type>(archetype::MmRosError_t::TENSORRT, os.str());
+    return archetype::make_err<outputs_type>(archetype::MmRosError_t::TENSORRT, os.str());
   }
 
   // 5. Execute postprocess
@@ -160,7 +160,7 @@ archetype::Result<outputs_type> SemanticSegmenter2D::postprocess(
         output_h.data(), output_d_.get(),
         sizeof(int64_t) * batch_size * 1 * output_width * output_height, ::cudaMemcpyDeviceToHost));
   } catch (const archetype::MmRosException & e) {
-    return archetype::Err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
+    return archetype::make_err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
   }
 
   outputs_type output;
@@ -197,6 +197,6 @@ archetype::Result<outputs_type> SemanticSegmenter2D::postprocess(
     output.push_back(std::move(final_mask));
   }
 
-  return archetype::Ok(output);
+  return archetype::make_ok(output);
 }
 }  // namespace mmros::detector


### PR DESCRIPTION
## Description

This pull request refactors the error handling and result construction code across the mmros project to use more consistent and descriptive function naming. The main changes involve renaming utility functions for constructing success and error results, updating method names for checking result status, and ensuring these changes are reflected throughout all relevant detector classes. This improves code readability and aligns with modern C++ naming conventions.

**Core API refactoring:**

* Renamed result construction functions in `mmros/include/mmros/archetype/result.hpp` from `Ok`/`Err` to `make_ok`/`make_err`, and updated all usages accordingly. [[1]](diffhunk://#diff-cdf7ca376d16734e98af79326aed49804d4f3af8c7838cb7aac5b35e5e444c05L77-R77) [[2]](diffhunk://#diff-cdf7ca376d16734e98af79326aed49804d4f3af8c7838cb7aac5b35e5e444c05L89-R89) [[3]](diffhunk://#diff-cdf7ca376d16734e98af79326aed49804d4f3af8c7838cb7aac5b35e5e444c05L101-R101) [[4]](diffhunk://#diff-cdf7ca376d16734e98af79326aed49804d4f3af8c7838cb7aac5b35e5e444c05L115-R115)
* Renamed the `isOk()` method in the `Result` class to `is_ok()` for consistency with the new naming convention.

**Exception handling improvements:**

* Renamed the internal method `appendMessagePrefix()` to `append_message_prefix()` in `MmRosException` and updated its usage for consistency. [[1]](diffhunk://#diff-0607b9b3c0ea4a42b08b40166ec22ad9dacecfedc41e7cc371c55a4b14da7062L68-R68) [[2]](diffhunk://#diff-0607b9b3c0ea4a42b08b40166ec22ad9dacecfedc41e7cc371c55a4b14da7062L78-R78) [[3]](diffhunk://#diff-0607b9b3c0ea4a42b08b40166ec22ad9dacecfedc41e7cc371c55a4b14da7062L90-R90)

**Detector classes updates:**

* Updated all detector classes (`Detector2D`, `InstanceSegmenter2D`, `PanopticSegmenter2D`, `SemanticSegmenter2D`) to use the new `make_ok` and `make_err` functions for constructing results, replacing all previous usages of `Ok` and `Err`. [[1]](diffhunk://#diff-3c42c7f2b5e0409ab29b675cdaa8c1bc7681544e03030e7684cb6c10bcd02105L80-R109) [[2]](diffhunk://#diff-3c42c7f2b5e0409ab29b675cdaa8c1bc7681544e03030e7684cb6c10bcd02105L187-R187) [[3]](diffhunk://#diff-3c42c7f2b5e0409ab29b675cdaa8c1bc7681544e03030e7684cb6c10bcd02105L213-R213) [[4]](diffhunk://#diff-49a7ef98e722eb7ad22af45979109245e1c6dd4a494a9460adfc2cf275d956ceL82-R108) [[5]](diffhunk://#diff-49a7ef98e722eb7ad22af45979109245e1c6dd4a494a9460adfc2cf275d956ceL199-R199) [[6]](diffhunk://#diff-49a7ef98e722eb7ad22af45979109245e1c6dd4a494a9460adfc2cf275d956ceL237-R237) [[7]](diffhunk://#diff-082137242d88fc2d4aebb9b3cdb88e3716482c3c209d38728a9aaf77fa41413fL79-R93) [[8]](diffhunk://#diff-082137242d88fc2d4aebb9b3cdb88e3716482c3c209d38728a9aaf77fa41413fL103-R110) [[9]](diffhunk://#diff-082137242d88fc2d4aebb9b3cdb88e3716482c3c209d38728a9aaf77fa41413fL219-R219) [[10]](diffhunk://#diff-082137242d88fc2d4aebb9b3cdb88e3716482c3c209d38728a9aaf77fa41413fL251-R251) [[11]](diffhunk://#diff-2ccc22aa135b5b818470220e8a19afa74f69dc3538fd35d7c3da0894a60b45f8L81-R110) [[12]](diffhunk://#diff-2ccc22aa135b5b818470220e8a19afa74f69dc3538fd35d7c3da0894a60b45f8L163-R163) [[13]](diffhunk://#diff-2ccc22aa135b5b818470220e8a19afa74f69dc3538fd35d7c3da0894a60b45f8L200-R200)

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
