### PR TITLE
refactor: apply snake_case to the function names

### DIFF
--- a/mmros/include/mmros/detector/detector2d.hpp
+++ b/mmros/include/mmros/detector/detector2d.hpp
@@ -81,7 +81,7 @@ public:
   /**
    * @brief Execute inference using input images. Returns `std::nullopt` if the inference fails.
    *
-   * @param images Vector of mutiple batch images.
+   * @param images Vector of multiple batch images.
    * @return archetype::Result<outputs_type>
    */
   archetype::Result<outputs_type> do_inference(const std::vector<cv::Mat> & images) noexcept;

--- a/mmros/include/mmros/detector/detector2d.hpp
+++ b/mmros/include/mmros/detector/detector2d.hpp
@@ -84,7 +84,7 @@ public:
    * @param images Vector of mutiple batch images.
    * @return archetype::Result<outputs_type>
    */
-  archetype::Result<outputs_type> doInference(const std::vector<cv::Mat> & images) noexcept;
+  archetype::Result<outputs_type> do_inference(const std::vector<cv::Mat> & images) noexcept;
 
 private:
   /**
@@ -94,7 +94,7 @@ private:
    *
    * @throw Throw `MmRosException` if any CUDA processing failed.
    */
-  void initCudaPtr(size_t batch_size);
+  void init_cuda_ptr(size_t batch_size);
 
   /**
    * @brief Execute preprocessing.

--- a/mmros/include/mmros/detector/instance_segmenter2d.hpp
+++ b/mmros/include/mmros/detector/instance_segmenter2d.hpp
@@ -82,7 +82,7 @@ public:
    * @param images Vector of multiple batch images.
    * @return archetype::Result<outputs_type>
    */
-  archetype::Result<outputs_type> doInference(const std::vector<cv::Mat> & images) noexcept;
+  archetype::Result<outputs_type> do_inference(const std::vector<cv::Mat> & images) noexcept;
 
 private:
   /**
@@ -92,7 +92,7 @@ private:
    *
    * @throw Throw `MmRosException` if any CUDA processing failed.
    */
-  void initCudaPtr(size_t batch_size);
+  void init_cuda_ptr(size_t batch_size);
 
   /**
    * @brief Execute preprocessing.

--- a/mmros/include/mmros/detector/panoptic_segmenter2d.hpp
+++ b/mmros/include/mmros/detector/panoptic_segmenter2d.hpp
@@ -84,7 +84,7 @@ public:
    * @param images Vector of multiple batch images.
    * @return archetype::Result<outputs_type>
    */
-  archetype::Result<outputs_type> doInference(const std::vector<cv::Mat> & images) noexcept;
+  archetype::Result<outputs_type> do_inference(const std::vector<cv::Mat> & images) noexcept;
 
 private:
   /**
@@ -94,7 +94,7 @@ private:
    *
    * @throw Throw `MmRosException` if any CUDA processing failed.
    */
-  void initCudaPtr(size_t batch_size);
+  void init_cuda_ptr(size_t batch_size);
 
   /**
    * @brief Execute preprocessing.

--- a/mmros/include/mmros/detector/semantic_segmenter2d.hpp
+++ b/mmros/include/mmros/detector/semantic_segmenter2d.hpp
@@ -77,7 +77,7 @@ public:
    * @param images Vector of multiple batch images.
    * @return Result<outputs_type>
    */
-  archetype::Result<outputs_type> doInference(const std::vector<cv::Mat> & images) noexcept;
+  archetype::Result<outputs_type> do_inference(const std::vector<cv::Mat> & images) noexcept;
 
 private:
   /**
@@ -87,7 +87,7 @@ private:
    *
    * @throw Throw `MmRosException` if any CUDA processing failed.
    */
-  void initCudaPtr(size_t batch_size);
+  void init_cuda_ptr(size_t batch_size);
 
   /**
    * @brief Execute preprocessing.

--- a/mmros/src/detector/detector2d.cpp
+++ b/mmros/src/detector/detector2d.cpp
@@ -73,7 +73,7 @@ Detector2D::Detector2D(tensorrt::TrtCommonConfig && trt_config, Detector2dConfig
   CHECK_CUDA_ERROR(cudaStreamCreate(&stream_));
 }
 
-archetype::Result<outputs_type> Detector2D::doInference(
+archetype::Result<outputs_type> Detector2D::do_inference(
   const std::vector<cv::Mat> & images) noexcept
 {
   if (images.empty()) {
@@ -82,7 +82,7 @@ archetype::Result<outputs_type> Detector2D::doInference(
 
   // 1. Init CUDA pointers
   try {
-    initCudaPtr(images.size());
+    init_cuda_ptr(images.size());
   } catch (const archetype::MmRosException & e) {
     return archetype::make_err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
   }
@@ -114,7 +114,7 @@ archetype::Result<outputs_type> Detector2D::doInference(
 }
 
 /// Initialize CUDA pointers.
-void Detector2D::initCudaPtr(size_t batch_size)
+void Detector2D::init_cuda_ptr(size_t batch_size)
 {
   auto get_dim_size = [&](const nvinfer1::Dims & dims) {
     return std::accumulate(dims.d + 1, dims.d + dims.nbDims, 1, std::multiplies<int>());

--- a/mmros/src/detector/instance_segmeter2d.cpp
+++ b/mmros/src/detector/instance_segmeter2d.cpp
@@ -75,7 +75,7 @@ InstanceSegmenter2D::InstanceSegmenter2D(
   CHECK_CUDA_ERROR(cudaStreamCreate(&stream_));
 }
 
-archetype::Result<outputs_type> InstanceSegmenter2D::doInference(
+archetype::Result<outputs_type> InstanceSegmenter2D::do_inference(
   const std::vector<cv::Mat> & images) noexcept
 {
   if (images.empty()) {
@@ -84,7 +84,7 @@ archetype::Result<outputs_type> InstanceSegmenter2D::doInference(
 
   // 1. Init CUDA pointers
   try {
-    initCudaPtr(images.size());
+    init_cuda_ptr(images.size());
   } catch (const archetype::MmRosException & e) {
     return archetype::make_err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
   }
@@ -112,7 +112,7 @@ archetype::Result<outputs_type> InstanceSegmenter2D::doInference(
   return postprocess(images);
 }
 
-void InstanceSegmenter2D::initCudaPtr(size_t batch_size)
+void InstanceSegmenter2D::init_cuda_ptr(size_t batch_size)
 {
   auto get_dim_size = [&](const nvinfer1::Dims & dims) {
     return std::accumulate(dims.d + 1, dims.d + dims.nbDims, 1, std::multiplies<int>());

--- a/mmros/src/detector/panoptic_segmenter2d.cpp
+++ b/mmros/src/detector/panoptic_segmenter2d.cpp
@@ -72,7 +72,7 @@ PanopticSegmenter2D::PanopticSegmenter2D(
   CHECK_CUDA_ERROR(cudaStreamCreate(&stream_));
 }
 
-archetype::Result<outputs_type> PanopticSegmenter2D::doInference(
+archetype::Result<outputs_type> PanopticSegmenter2D::do_inference(
   const std::vector<cv::Mat> & images) noexcept
 {
   if (images.empty()) {
@@ -81,7 +81,7 @@ archetype::Result<outputs_type> PanopticSegmenter2D::doInference(
 
   // 1. Init CUDA pointers
   try {
-    initCudaPtr(images.size());
+    init_cuda_ptr(images.size());
   } catch (const archetype::MmRosException & e) {
     return archetype::make_err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
   }
@@ -114,7 +114,7 @@ archetype::Result<outputs_type> PanopticSegmenter2D::doInference(
   return postprocess(images);
 }
 
-void PanopticSegmenter2D::initCudaPtr(size_t batch_size)
+void PanopticSegmenter2D::init_cuda_ptr(size_t batch_size)
 {
   auto get_dim_size = [&](const nvinfer1::Dims & dims) {
     return std::accumulate(dims.d + 1, dims.d + dims.nbDims, 1, std::multiplies<int>());

--- a/mmros/src/detector/semantic_segmenter2d.cpp
+++ b/mmros/src/detector/semantic_segmenter2d.cpp
@@ -74,7 +74,7 @@ SemanticSegmenter2D::SemanticSegmenter2D(
   CHECK_CUDA_ERROR(cudaStreamCreate(&stream_));
 }
 
-archetype::Result<outputs_type> SemanticSegmenter2D::doInference(
+archetype::Result<outputs_type> SemanticSegmenter2D::do_inference(
   const std::vector<cv::Mat> & images) noexcept
 {
   if (images.empty()) {
@@ -83,7 +83,7 @@ archetype::Result<outputs_type> SemanticSegmenter2D::doInference(
 
   // 1. Init CUDA pointers
   try {
-    initCudaPtr(images.size());
+    init_cuda_ptr(images.size());
   } catch (const archetype::MmRosException & e) {
     return archetype::make_err<outputs_type>(archetype::MmRosError_t::CUDA, e.what());
   }
@@ -114,7 +114,7 @@ archetype::Result<outputs_type> SemanticSegmenter2D::doInference(
   return postprocess(images);
 }
 
-void SemanticSegmenter2D::initCudaPtr(size_t batch_size)
+void SemanticSegmenter2D::init_cuda_ptr(size_t batch_size)
 {
   auto get_dim_size = [&](const nvinfer1::Dims & dims) {
     return std::accumulate(dims.d + 1, dims.d + dims.nbDims, 1, std::multiplies<int>());

--- a/mmros/src/node/detection2d_node.cpp
+++ b/mmros/src/node/detection2d_node.cpp
@@ -88,7 +88,7 @@ void Detection2dNode::onImage(sensor_msgs::msg::Image::ConstSharedPtr msg)
   std::vector<archetype::Boxes2D> batch_boxes;
   try {
     std::vector<cv::Mat> images{in_image_ptr->image};
-    batch_boxes = detector_->doInference(images).unwrap();
+    batch_boxes = detector_->do_inference(images).unwrap();
   } catch (const archetype::MmRosException & e) {
     RCLCPP_ERROR_STREAM(get_logger(), e.what());
     return;

--- a/mmros/src/node/instance_segmentation2d_node.cpp
+++ b/mmros/src/node/instance_segmentation2d_node.cpp
@@ -90,7 +90,7 @@ void InstanceSegmentation2dNode::onImage(sensor_msgs::msg::Image::ConstSharedPtr
   std::vector<std::pair<archetype::Boxes2D, std::vector<cv::Mat>>> batch_outputs;
   try {
     std::vector<cv::Mat> images{in_image_ptr->image};
-    batch_outputs = detector_->doInference(images).unwrap();
+    batch_outputs = detector_->do_inference(images).unwrap();
   } catch (const archetype::MmRosException & e) {
     RCLCPP_ERROR_STREAM(get_logger(), e.what());
     return;

--- a/mmros/src/node/panoptic_segmentation2d_node.cpp
+++ b/mmros/src/node/panoptic_segmentation2d_node.cpp
@@ -85,7 +85,7 @@ void PanopticSegmentation2dNode::onImage(const sensor_msgs::msg::Image::ConstSha
   std::vector<std::pair<archetype::Boxes2D, cv::Mat>> batch_outputs;
   try {
     std::vector<cv::Mat> images{in_image_ptr->image};
-    batch_outputs = detector_->doInference(images).unwrap();
+    batch_outputs = detector_->do_inference(images).unwrap();
   } catch (const archetype::MmRosException & e) {
     RCLCPP_ERROR_STREAM(get_logger(), e.what());
     return;

--- a/mmros/src/node/semantic_segmentation2d_node.cpp
+++ b/mmros/src/node/semantic_segmentation2d_node.cpp
@@ -79,7 +79,7 @@ void SemanticSegmentation2dNode::onImage(const sensor_msgs::msg::Image::ConstSha
   std::vector<cv::Mat> batch_masks;
   try {
     std::vector<cv::Mat> images{in_image_ptr->image};
-    batch_masks = detector_->doInference(images).unwrap();
+    batch_masks = detector_->do_inference(images).unwrap();
   } catch (const archetype::MmRosException & e) {
     RCLCPP_ERROR_STREAM(get_logger(), e.what());
     return;


### PR DESCRIPTION
## Description

This pull request refactors the codebase to improve naming consistency and clarity for CUDA initialization and inference methods across all 2D detector and segmenter classes. The changes update method names from camelCase to snake_case in both header and source files, and propagate these updates to all usages in node classes. No logic is changed—this is a pure renaming refactor.

### Method renaming for consistency

* Renamed all `doInference` methods to `do_inference` in the following classes and their corresponding source files: `Detector2D`, `InstanceSegmenter2D`, `PanopticSegmenter2D`, and `SemanticSegmenter2D`. [[1]](diffhunk://#diff-611073c9ae62dce587ec7b0561c22c78051890f4e9b7377279eb2e52a19dbc37L84-R87) [[2]](diffhunk://#diff-125637157667947407eefdc7f89e997f5ae58d95bb8c016aee20e576b2174df0L85-R85) [[3]](diffhunk://#diff-433a0b51e9b329dbe54be833ab9ce295bdd9e59b96b2b6a5ae6bef1e20d262a0L87-R87) [[4]](diffhunk://#diff-67d28a0bef1e53cf08fdaf2256d454efce574a7d3282fe09426acd5c0cca1effL80-R80) [[5]](diffhunk://#diff-3c42c7f2b5e0409ab29b675cdaa8c1bc7681544e03030e7684cb6c10bcd02105L76-R76) [[6]](diffhunk://#diff-49a7ef98e722eb7ad22af45979109245e1c6dd4a494a9460adfc2cf275d956ceL78-R78) [[7]](diffhunk://#diff-082137242d88fc2d4aebb9b3cdb88e3716482c3c209d38728a9aaf77fa41413fL75-R75) [[8]](diffhunk://#diff-2ccc22aa135b5b818470220e8a19afa74f69dc3538fd35d7c3da0894a60b45f8L77-R77)
* Renamed all `initCudaPtr` methods to `init_cuda_ptr` in the same classes and files. [[1]](diffhunk://#diff-611073c9ae62dce587ec7b0561c22c78051890f4e9b7377279eb2e52a19dbc37L97-R97) [[2]](diffhunk://#diff-125637157667947407eefdc7f89e997f5ae58d95bb8c016aee20e576b2174df0L95-R95) [[3]](diffhunk://#diff-433a0b51e9b329dbe54be833ab9ce295bdd9e59b96b2b6a5ae6bef1e20d262a0L97-R97) [[4]](diffhunk://#diff-67d28a0bef1e53cf08fdaf2256d454efce574a7d3282fe09426acd5c0cca1effL90-R90) [[5]](diffhunk://#diff-3c42c7f2b5e0409ab29b675cdaa8c1bc7681544e03030e7684cb6c10bcd02105L117-R117) [[6]](diffhunk://#diff-49a7ef98e722eb7ad22af45979109245e1c6dd4a494a9460adfc2cf275d956ceL115-R115) [[7]](diffhunk://#diff-082137242d88fc2d4aebb9b3cdb88e3716482c3c209d38728a9aaf77fa41413fL117-R117) [[8]](diffhunk://#diff-2ccc22aa135b5b818470220e8a19afa74f69dc3538fd35d7c3da0894a60b45f8L117-R117)

### Propagation of new method names

* Updated all usages of the renamed inference methods in node classes: `Detection2dNode`, `InstanceSegmentation2dNode`, `PanopticSegmentation2dNode`, and `SemanticSegmentation2dNode`. [[1]](diffhunk://#diff-2427715b9e9a2844842180629c6af276707daf024579e6cddf8783cb3df0471eL91-R91) [[2]](diffhunk://#diff-34e3735e8078f1b33971297043319bf29c008543f3bbd3ff7dbbc86a70caa8a9L93-R93) [[3]](diffhunk://#diff-968b8e432bfe7c2140b645472f63f062229f5449467340ff07dd7076eb76e18dL88-R88) [[4]](diffhunk://#diff-2dc74a650a1433ff0ba857c1a6ac8c8ffd73f760b6ad527342ddeb1edccdd709L82-R82)
* Updated calls to the renamed CUDA initialization methods within the inference implementations. [[1]](diffhunk://#diff-3c42c7f2b5e0409ab29b675cdaa8c1bc7681544e03030e7684cb6c10bcd02105L85-R85) [[2]](diffhunk://#diff-49a7ef98e722eb7ad22af45979109245e1c6dd4a494a9460adfc2cf275d956ceL87-R87) [[3]](diffhunk://#diff-082137242d88fc2d4aebb9b3cdb88e3716482c3c209d38728a9aaf77fa41413fL84-R84) [[4]](diffhunk://#diff-2ccc22aa135b5b818470220e8a19afa74f69dc3538fd35d7c3da0894a60b45f8L86-R86)

These changes help standardize method naming, making the codebase easier to read and maintain.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
